### PR TITLE
[feat] 캔버스 드로잉 및 draw 데이터 추출 기능 구현

### DIFF
--- a/client/src/features/canvasDraw/ui/Canvas.tsx
+++ b/client/src/features/canvasDraw/ui/Canvas.tsx
@@ -1,11 +1,13 @@
 import { useRef, useState, useEffect } from 'react';
 
+type Stroke = [x: number[], y: number[]];
+
 export function Canvas() {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const ctxRef = useRef<CanvasRenderingContext2D | null>(null);
   const [isDrawing, setIsDrawing] = useState(false);
-  const currentStrokeRef = useRef<[number[], number[]] | null>(null); // 현재 그리고 있는 stroke
-  const strokesRef = useRef<[number[], number[]][]>([]); // 모든 stroke
+  const currentStrokeRef = useRef<Stroke | null>(null); // 현재 그리고 있는 stroke
+  const strokesRef = useRef<Stroke[]>([]); // 모든 stroke
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -57,9 +59,8 @@ export function Canvas() {
   const handleMouseMove = (e: React.MouseEvent) => {
     const ctx = ctxRef.current;
     if (!ctx) return;
-
-    const { x, y } = getMousePosOnCanvas(e);
     if (!isDrawing) return;
+    const { x, y } = getMousePosOnCanvas(e);
     ctx.lineTo(x, y);
     ctx.stroke();
 
@@ -74,7 +75,6 @@ export function Canvas() {
     if (!isDrawing) return;
     ctx.closePath();
     setIsDrawing(false);
-    console.log('현재까지 그린 데이터:', strokesRef.current);
     // 현재 스트로크를 전체 스트로크에 저장
     if (currentStrokeRef.current) {
       strokesRef.current.push(currentStrokeRef.current);


### PR DESCRIPTION
## 개요

> 이번 PR에서 해결한 내용 또는 추가된 기능을 요약해주세요

마우스 드래그를 통해 캔버스에 그림을 그릴 수 있는 기본 드로잉 기능을 구현했습니다. 
Canvas API를 활용하여 실시간 드로잉이 가능하며, 각 스트로크(획)의 좌표 데이터를 저장하여 추후 유사도 검사에 활용할 수 있도록 했습니다.



## 관련 이슈

> #6

## 변경 사항

### 0. Canvas 관련 학습 정리
https://www.notion.so/canvas-2cd2e762b5c480ea9301e4e940fa8298?source=copy_link

### 1. Canvas 컴포넌트 구현
새로운 Canvas 컴포넌트를 `client/src/features/canvasDraw/ui/Canvas.tsx`에 구현했습니다.

**주요 기능**
- **마우스 이벤트 기반 드로잉**: mousedown, mousemove, mouseup, mouseout 이벤트를 활용한 실시간 그리기
- **좌표 변환 처리**: 브라우저 좌표를 캔버스 픽셀 좌표로 정확하게 변환
- **에지 케이스 처리**: 캔버스 밖으로 마우스가 나갔을 때 자동으로 그리기 종료

<br />

### 2. 드로잉 데이터 저장 구조

```typescript
Stroke = [x: number[], y: number[]];
```

각 획(Stroke)은 x좌표 배열과 y좌표 배열의 튜플로 저장됩니다.

**저장 구조:**
- **currentStrokeRef**: 현재 그리고 있는 획의 좌표를 실시간으로 기록
  - 마우스를 움직일 때마다 x, y 좌표가 각 배열에 추가됨
  - 예: `[[100, 101, 102], [200, 201, 202]]` - 3개의 점으로 이루어진 획
  
- **strokesRef**: 완성된 모든 획들을 저장하는 배열
  - 마우스를 뗄 때(mouseup) currentStroke가 strokesRef에 추가됨
  - 여러 획을 그릴 때마다 누적되어 전체 그림 데이터가 됨
  - 예: `[[[10,11], [20,21]], [[30,31], [40,41]]]` - 2개의 획

**데이터 흐름:**
1. 그리기 시작(mousedown) → currentStrokeRef 초기화
2. 그리는 중(mousemove) → currentStrokeRef에 좌표 추가
3. 그리기 종료(mouseup) → currentStrokeRef를 strokesRef에 저장
4. 추후 strokesRef 데이터를 서버로 전송하거나 유사도 검사에 활용


<br />

### 3. Canvas API 설정
드로잉에 최적화된 Canvas 렌더링 컨텍스트를 설정했습니다 
- 흰색 배경으로 초기화
- 부드러운 선 표현을 위한 `lineCap: 'round'`, `lineJoin: 'round'` 설정
- 선 굵기 3px, 검은색 스타일 적용


```ts
  useEffect(() => {
    const canvas = canvasRef.current;
    if (!canvas) return;

    const ctx = canvas.getContext('2d');
    if (!ctx) return;

    ctx.fillStyle = 'white';
    ctx.fillRect(0, 0, canvas.width, canvas.height);

    ctx.lineCap = 'round';
    ctx.lineJoin = 'round';
    ctx.lineWidth = 3;
    ctx.strokeStyle = 'black';

    ctxRef.current = ctx;
  }, []);

```

### 체크리스트

<!-- 리뷰 전에 본인이 확인해야 하는 항목 -->

- [x]  코드 스타일 가이드/린트 규칙을 준수했습니다.
- [x]  불필요한 콘솔/디버깅 코드를 제거했습니다.
- [x]  주석/변수명 등 가독성을 고려했습니다.
- [x]  영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [x]  API, DB 변경 시 문서화했습니다.
- [x]  새로운 의존성 추가 시 팀과 공유했습니다.

<br />


## 테스트 및 검증 내용
마우스 드래그로 그림을 그리고, strokesRef에 좌표 데이터가 올바르게 저장되는지 콘솔로 확인했습니다.

<br />

## AI 활용 점검
이번 작업에서는 AI를 사용하지 않고 Canvas API 문서를 직접 참고하여 마우스 이벤트 기반 드로잉을 구현했습니다.


<br />


## 스크린샷 / UI 변경 (선택)

> UI가 변경된 경우 스크린샷을 첨부해주세요

직접 구현한 canvas로 팀원들 응원하기!!!

<img width="446" height="391" alt="image" src="https://github.com/user-attachments/assets/43a639fd-158e-4097-8ef6-bc221288bad1" />


