### PR TITLE
[feat] 최종 결과 페이지 디자인 및 UI 구현

### DIFF
--- a/client/src/app/config/router/index.tsx
+++ b/client/src/app/config/router/index.tsx
@@ -1,13 +1,13 @@
 import type { RouteObject } from 'react-router-dom';
 import { PATHS } from '@/shared/config';
-import LandingPage from '@/pages/main/Landingpage';
 
 import { Game } from '@/pages/game';
+import Main from '@/pages/main/Main';
 
 export const routes: RouteObject[] = [
   {
     path: PATHS.HOME,
-    element: <LandingPage />,
+    element: <Main />,
   },
   {
     path: PATHS.GAME,

--- a/client/src/entities/gameResult/index.ts
+++ b/client/src/entities/gameResult/index.ts
@@ -1,0 +1,2 @@
+export { PodiumPlayer } from './ui';
+export type { PlayerResult, GameResultData } from './model';

--- a/client/src/entities/gameResult/model/index.ts
+++ b/client/src/entities/gameResult/model/index.ts
@@ -1,0 +1,1 @@
+export type { PlayerResult, GameResultData } from './types';

--- a/client/src/entities/gameResult/model/types.ts
+++ b/client/src/entities/gameResult/model/types.ts
@@ -1,0 +1,12 @@
+export interface PlayerResult {
+  rank: number;
+  nickname: string;
+  score: number;
+  isCurrentUser?: boolean;
+  avatar?: string;
+}
+
+export interface GameResultData {
+  players: PlayerResult[];
+  totalRounds: number;
+}

--- a/client/src/entities/gameResult/ui/PodiumPlayer.tsx
+++ b/client/src/entities/gameResult/ui/PodiumPlayer.tsx
@@ -1,0 +1,124 @@
+import type { PlayerResult } from '../model/types';
+
+interface PodiumPlayerProps {
+  player: PlayerResult;
+  position: 'first' | 'second' | 'third';
+}
+
+const PODIUM_CONFIG = {
+  first: {
+    order: 'order-1 sm:order-2',
+    size: 'h-28 w-28 sm:h-32 sm:w-32',
+    borderColor: 'border-yellow-400',
+    textColor: 'text-yellow-600',
+    nameSize: 'text-3xl',
+    scoreSize: 'text-2xl',
+    podiumHeight: 'h-28 sm:h-32',
+    podiumWidth: 'w-20 sm:w-24',
+    podiumBg: 'bg-yellow-100',
+    podiumBorder: 'border-yellow-200',
+    badge: {
+      bg: 'bg-yellow-500',
+      text: '#1',
+    },
+    showTrophy: true,
+    showRankNumber: true,
+  },
+  second: {
+    order: 'order-2 sm:order-1',
+    size: 'h-20 w-20 sm:h-24 sm:w-24',
+    borderColor: 'border-indigo-400',
+    textColor: 'text-indigo-600',
+    nameSize: 'text-xl',
+    scoreSize: 'text-lg',
+    podiumHeight: 'h-20 sm:h-24',
+    podiumWidth: 'w-16 sm:w-20',
+    podiumBg: 'bg-indigo-100',
+    podiumBorder: 'border-indigo-200',
+    badge: {
+      bg: 'bg-indigo-500',
+      text: '#2',
+    },
+    showTrophy: false,
+    showRankNumber: false,
+  },
+  third: {
+    order: 'order-3',
+    size: 'h-20 w-20 sm:h-24 sm:w-24',
+    borderColor: 'border-pink-400',
+    textColor: 'text-pink-600',
+    nameSize: 'text-xl',
+    scoreSize: 'text-lg',
+    podiumHeight: 'h-14 sm:h-16',
+    podiumWidth: 'w-16 sm:w-20',
+    podiumBg: 'bg-pink-100',
+    podiumBorder: 'border-pink-200',
+    badge: {
+      bg: 'bg-pink-400',
+      text: '#3',
+    },
+    showTrophy: false,
+    showRankNumber: false,
+  },
+};
+
+const MEDAL_EMOJI = {
+  first: '🏆',
+  second: '🥈',
+  third: '🥉',
+};
+
+export const PodiumPlayer = ({ player, position }: PodiumPlayerProps) => {
+  const config = PODIUM_CONFIG[position];
+
+  return (
+    <div className={`${config.order} flex flex-col items-center`}>
+      <div className="group relative">
+        <div
+          className={`${config.size} relative mb-3 flex items-center justify-center overflow-hidden rounded-full border-4 ${config.borderColor} bg-white shadow-${position === 'first' ? 'xl' : 'lg'}`}
+        >
+          {player.avatar ? (
+            <img
+              alt={`${player.nickname} avatar`}
+              className="h-full w-full object-cover"
+              src={player.avatar}
+            />
+          ) : (
+            <span className="text-3xl select-none">
+              {MEDAL_EMOJI[position]}
+            </span>
+          )}
+        </div>
+
+        {config.badge && (
+          <div
+            className={`absolute -top-2 -right-2 ${config.badge.bg} rounded-full px-2 py-1 text-xs font-bold text-white`}
+          >
+            {config.badge.text}
+          </div>
+        )}
+
+        {position === 'first' && (
+          <div className="absolute -bottom-2 left-1/2 -translate-x-1/2 transform rounded-full bg-yellow-400 px-4 py-1 font-bold whitespace-nowrap text-gray-800 shadow-sm">
+            오늘의 다빈치
+          </div>
+        )}
+      </div>
+
+      <h3
+        className={`font-handwriting ${config.nameSize} font-bold text-gray-800 ${position === 'first' ? 'mt-4' : ''}`}
+      >
+        {player.nickname}
+        {player.isCurrentUser && ' (You)'}
+      </h3>
+
+      <p className={`${config.textColor} ${config.scoreSize} font-bold`}>
+        {player.score.toLocaleString()} pts
+      </p>
+
+      <div
+        className={`${config.podiumHeight} ${config.podiumWidth} ${config.podiumBg} mt-2 rounded-t-lg border-x-2 border-t-2 ${config.podiumBorder} ${position === 'first' ? 'flex items-end justify-center pb-2' : ''}`}
+      ></div>
+    </div>
+  );
+};

--- a/client/src/entities/gameResult/ui/index.ts
+++ b/client/src/entities/gameResult/ui/index.ts
@@ -1,0 +1,1 @@
+export { PodiumPlayer } from './PodiumPlayer';

--- a/client/src/pages/game/Game.tsx
+++ b/client/src/pages/game/Game.tsx
@@ -15,7 +15,7 @@ const GAME_PHASE_COMPONENT_MAP = {
 const Game = () => {
   //   const [gamePhase, setGamePhase] = useState<GamePhase>('WAITING');
 
-  const gamePhase = 'ROUND_END';
+  const gamePhase = 'GAME_END';
   const PhaseComponent = GAME_PHASE_COMPONENT_MAP[gamePhase];
 
   return <PhaseComponent />;

--- a/client/src/pages/main/Main.tsx
+++ b/client/src/pages/main/Main.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { NicknameInputModal } from '@/features/nickname';
 
-const LandingPage = () => {
+const Main = () => {
   const navigate = useNavigate();
   const [showNicknameModal, setShowNicknameModal] = useState(() => {
     return !localStorage.getItem('nickname');
@@ -114,4 +114,4 @@ const LandingPage = () => {
   );
 };
 
-export default LandingPage;
+export default Main;

--- a/client/src/pages/main/index.ts
+++ b/client/src/pages/main/index.ts
@@ -1,1 +1,1 @@
-export { default as Landingpage } from './Landingpage';
+export { default as Landingpage } from './Main';

--- a/client/src/shared/config/titles/index.ts
+++ b/client/src/shared/config/titles/index.ts
@@ -2,4 +2,5 @@ export const TITLES = {
   MAIN: '우리 모두 다빈치',
   CREATE: '방 만들기',
   ROOM: '게임방',
+  END: '최종 결과',
 };

--- a/client/src/widgets/gameEnd/ui/GameEnd.tsx
+++ b/client/src/widgets/gameEnd/ui/GameEnd.tsx
@@ -1,3 +1,94 @@
+import { PodiumPlayer } from '@/entities/gameResult';
+import type { GameResultData } from '@/entities/gameResult';
+import { PATHS, TITLES } from '@/shared/config';
+import { CommonBtn, Title } from '@/shared/ui';
+
+const DUMMY_DATA: GameResultData = {
+  totalRounds: 10,
+  players: [
+    {
+      rank: 1,
+      nickname: 'User 1',
+      score: 2400,
+      isCurrentUser: true,
+    },
+    {
+      rank: 2,
+      nickname: 'Player 2',
+      score: 1850,
+      isCurrentUser: false,
+    },
+    {
+      rank: 3,
+      nickname: 'Player 3',
+      score: 1200,
+      isCurrentUser: false,
+    },
+    {
+      rank: 4,
+      nickname: 'Player 4',
+      score: 450,
+      isCurrentUser: false,
+    },
+  ],
+};
+
 export const GameEnd = () => {
-  return <div>GameEnd</div>;
+  const topThree = DUMMY_DATA.players.slice(0, 3);
+
+  return (
+    <div className="h-screen">
+      <main className="flex h-full flex-col items-center justify-center px-4 py-12">
+        <div className="flex w-full flex-col">
+          <div className="mb-5 shrink-0 text-center">
+            <Title title={TITLES.END} fontSize="text-6xl" />
+            <div className="mx-auto mt-1 h-1.5 w-40 rounded-full bg-yellow-300" />
+          </div>
+        </div>
+
+        <div className="flex h-full w-full max-w-6xl flex-col items-start justify-between lg:flex-row">
+          <div className="flex h-full w-full justify-center">
+            <div className="flex h-full w-full max-w-lg flex-col rounded-2xl border-2 border-gray-200 bg-white p-6 shadow-xl">
+              <div className="mb-4 flex items-center justify-between border-b border-dashed border-gray-300 pb-2">
+                <div className="font-handwriting text-2xl text-gray-800">
+                  <span className="material-symbols-outlined mr-1 align-middle text-yellow-500">
+                    leaderboard
+                  </span>
+                  1등 POTG
+                </div>
+                <span className="text-sm text-gray-500">
+                  Total Rounds: {DUMMY_DATA.totalRounds}
+                </span>
+              </div>
+
+              <div className="flex-1">리플레이를 넣어라</div>
+            </div>
+          </div>
+
+          <div className="flex w-full flex-col items-center gap-10 pt-4">
+            <div className="flex w-full flex-col items-end justify-center gap-6 sm:flex-row">
+              {topThree[1] && (
+                <PodiumPlayer player={topThree[1]} position="second" />
+              )}
+              {topThree[0] && (
+                <PodiumPlayer player={topThree[0]} position="first" />
+              )}
+              {topThree[2] && (
+                <PodiumPlayer player={topThree[2]} position="third" />
+              )}
+            </div>
+
+            <div className="flex w-full max-w-md flex-col justify-center gap-4 sm:flex-row">
+              <CommonBtn
+                variant="radius"
+                icon="replay"
+                text="다시하기"
+                path={PATHS.GAME}
+              />
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
 };


### PR DESCRIPTION
## 개요

### 🎯 주요 변경 사항

#### 1. 신규 파일 생성

* **📁 `client/src/entities/gameResult/**`
* `model/types.ts`: 게임 결과 데이터 타입 정의
* `ui/PodiumPlayer.tsx`: 시상대 플레이어 컴포넌트


* **📁 `client/src/pages/main/Main.tsx**`
* 기존 `Landingpage.tsx`를 `Main.tsx`로 리팩토링

#### 2. 주요 수정 사항

* **`client/src/widgets/gameEnd/ui/GameEnd.tsx`**
* 빈 페이지에서 완전한 게임 종료 화면으로 구현
* **1~3등 시상대 UI** 추가
* **1등 POTG(Play of the Game)** 리플레이 영역 추가 (현재는 비어있어요.)
* **다시하기** 버튼 추가


* **`client/src/shared/config/titles/index.ts`**
* `END: '최종 결과'` 타이틀 상수 추가


* **기타**
* 라우터 설정 및 페이지 import 경로 업데이트

---

### 📂 파일 위치 선정 이유 (FSD 아키텍처 적용)

**`entities/gameResult/`를 Entity 레이어에 배치한 이유:**

- 한 게임에서 플레이어의 순위라는 데이터를 보여주는 도메인이라고 생각해서 entites에 배치했습니다. 의견이 있으시다면 공유해주시면 좋을 것 같습니다!

---

## 관련 이슈

> - #49 

- 다음부터는 이슈 번호랑 브랜치 번호 잘 맞추겠습니다! 이번에는 이전 브랜치에서 추가 작업 느낌이라 이슈만 새로 팠더니 번호가 다르네용.

## 변경 사항

### 체크리스트

<!-- 리뷰 전에 본인이 확인해야 하는 항목 -->

- [x] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [x] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [x] 주석/변수명 등 가독성을 고려했습니다.
- [x] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [x] API, DB 변경 시 문서화했습니다.
- [x] 새로운 의존성 추가 시 팀과 공유했습니다.

## AI 활용 점검

> AI stitch를 이용해 디자인 틀을 잡고, 받은 html 코드를 리액트 형식으로 변경하는데 사용

## 추가 참고 사항

> 서버에서 1,2,3위만 따로 보내는게 나을지, 플레이어 정보를 순위대로 정렬해서 보내는게 나을지 고민하다가 일단은 UI 확인을 위해서 플레이어 목록 전체를 점수 순위대로 정렬해서 보내준다는 가정 하에 인덱스 2까지만 슬라이싱해서 컴포넌트 띄우는 방식으로 작업했습니다.

> 서버에서 어떤 형식이 편한지 의견 주시면 좋을 것 같습니다.

> FSD 아키텍쳐 형식으로 구현하면서 파일 네이밍에 대한 어려움이 있는데, 나중에 모여서 다같이 맞추고 다 변경하는 식으로 한 번 하면 좋을 것 같습니다.

## 스크린샷 / UI 변경 (선택)

<img width="1919" height="871" alt="image" src="https://github.com/user-attachments/assets/0b555b50-078b-4e50-a5af-f9aae75e8533" />

