### PR TITLE
[fix] 중복 에러 캡쳐 방지를 위한 Http error와 fetch error 구분

### DIFF
--- a/client/src/shared/api/rest/fetchClient.ts
+++ b/client/src/shared/api/rest/fetchClient.ts
@@ -41,6 +41,10 @@ export const fetchClient = async <TResponse, TBody = unknown>(
 
     return response.json();
   } catch (error) {
+    if (error instanceof Error && error.message.startsWith('HTTP error!')) {
+      throw error;
+    }
+
     Sentry.captureException(error, {
       tags: {
         error_type: 'fetch_error',


### PR DESCRIPTION
## 개요

> catch에서 throw error를 다시 하기 때문에 sentry에 중복 캡쳐

> try 문에서는 status에 따른 에러를 캡쳐하고 catch 문에서는 network 에러를 캡쳐하는 식으로 구분 

## 관련 이슈

> ex) Closes #12, Fixes #33

- #81 

## 변경 사항

### 체크리스트

<!-- 리뷰 전에 본인이 확인해야 하는 항목 -->

- [x] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [x] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [x] 주석/변수명 등 가독성을 고려했습니다.
- [x] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [x] API, DB 변경 시 문서화했습니다.
- [x] 새로운 의존성 추가 시 팀과 공유했습니다.

## 테스트 및 검증 내용

> 어떻게 테스트했고, 어떤 결과를 확인했는지 적어주세요.

<img width="1468" height="196" alt="image" src="https://github.com/user-attachments/assets/9fd04f50-1831-46ec-af2e-089c0bed1232" />

- 실제로 중복 캡쳐가 발생하는 것을 확인