### PR TITLE
[feat] 프롬프트 그림 랜덤 선택 기능 구현

### DIFF
--- a/server/src/common/types/game-room.types.ts
+++ b/server/src/common/types/game-room.types.ts
@@ -18,6 +18,7 @@ export interface GameRoom {
   phase: Phase;
   currentRound: number;
   settings: Settings;
+  promptId: number;
 }
 
 export type Phase = (typeof GamePhase)[keyof typeof GamePhase];

--- a/server/src/game/game.service.spec.ts
+++ b/server/src/game/game.service.spec.ts
@@ -124,6 +124,7 @@ describe('GameService', () => {
           maxPlayer: 4,
           totalRounds: 5,
         },
+        promptId: 1,
       };
 
       cacheService.getRoom

--- a/server/src/redis/cache/game-room-cache.service.ts
+++ b/server/src/redis/cache/game-room-cache.service.ts
@@ -28,6 +28,7 @@ export class GameRoomCacheService {
       phase: gameRoom.phase,
       currentRound: String(gameRoom.currentRound),
       settings: JSON.stringify(gameRoom.settings),
+      promptId: gameRoom.promptId,
     });
 
     await client.expire(key, REDIS_TTL);
@@ -51,6 +52,7 @@ export class GameRoomCacheService {
       phase: data.phase,
       currentRound: parseInt(data.currentRound),
       settings: JSON.parse(data.settings) as Settings,
+      promptId: parseInt(data.promptId),
     };
   }
 

--- a/server/src/round/round.service.ts
+++ b/server/src/round/round.service.ts
@@ -77,7 +77,10 @@ export class RoundService implements OnModuleInit {
     room.phase = GamePhase.PROMPT;
     room.currentRound += 1;
 
-    const promptStrokes = await this.getPromptForRound(room.currentRound);
+    const promptStrokes = await this.getPromptForRound(
+      room.promptId,
+      room.currentRound,
+    );
     if (!promptStrokes) {
       throw new Error('제시 그림 불러오기에 실패했습니다.');
     }
@@ -124,7 +127,8 @@ export class RoundService implements OnModuleInit {
 
     const result = {
       rankings: rankings,
-      promptStrokes: (await this.getPromptForRound(room.currentRound)) || [],
+      promptStrokes:
+        (await this.getPromptForRound(room.promptId, room.currentRound)) || [],
     };
 
     await this.timerService.startTimer(room.roomId, 10);
@@ -185,7 +189,8 @@ export class RoundService implements OnModuleInit {
     const finalResult = {
       finalRankings: rankings,
       highlight: {
-        promptStrokes: (await this.getPromptForRound(highlight.round)) || [],
+        promptStrokes:
+          (await this.getPromptForRound(room.promptId, highlight.round)) || [],
         playerStrokes: highlight.strokes,
         similarity: highlight.similarity,
       },
@@ -217,9 +222,12 @@ export class RoundService implements OnModuleInit {
     return promptStrokesData;
   }
 
-  private async getPromptForRound(round: number): Promise<Stroke[] | null> {
+  private async getPromptForRound(
+    promptId: number,
+    round: number,
+  ): Promise<Stroke[] | null> {
     const promptStrokesData = await this.loadPromptStrokes();
-    const index = round - 1;
+    const index = (promptId + round - 1) % promptStrokesData.length;
     if (index < 0 || index >= promptStrokesData.length) {
       return null;
     }


### PR DESCRIPTION
## 개요

매 게임마다 랜덤한 그림을 보여주도록 구현합니다.

## 관련 이슈
- Closes #114 

## 변경 사항

- `GameRoom`: promptId 추가 
  - 첫 라운드 프롬프트를 설정하고, 이후 라운드는 +1 한 그림을 보여줍니다.
- `createRoom`: 방을 생성할 때 랜덤 프롬프트 인덱스를 설정합니다.
-  `roundService`: getPromptForRound(promptId, round)로 수정

### 체크리스트

- [x] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [x] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [x] 주석/변수명 등 가독성을 고려했습니다.
- [x] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [x] API, DB 변경 시 문서화했습니다.
- [x] 새로운 의존성 추가 시 팀과 공유했습니다.

## 테스트 및 검증 내용

다 함께 테스트하였습니다.

## AI 활용 점검


## 추가 참고 사항


## 스크린샷 / UI 변경 (선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게임 룸이 무작위로 할당된 프롬프트 세트를 지원합니다. 각 라운드에서 프롬프트는 할당된 세트에서 순차적으로 선택되어 더 다양한 게임 플레이 경험을 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->