### PR TITLE
[fix] 그리기 단계에서 undo 시 stroke 중복 스케일링으로 인한 다시 그려지는 문제 해결

### DIFF
--- a/client/src/features/drawingCanvas/lib/drawStrokesOnCanvas.ts
+++ b/client/src/features/drawingCanvas/lib/drawStrokesOnCanvas.ts
@@ -5,52 +5,57 @@ import {
 } from '@/shared/lib/scaleStrokesToCanvas';
 import type { RefObject } from 'react';
 
-// 캔버스에 strokes를 그리는 유틸 함수
 export const drawStrokesOnCanvas = (
   canvasRef: RefObject<HTMLCanvasElement | null>,
   ctxRef: RefObject<CanvasRenderingContext2D | null>,
   strokes: Stroke[],
+  shouldScale: boolean = true,
 ) => {
   const ctx = ctxRef.current;
   const canvas = canvasRef.current;
   if (!ctx || !canvas || !strokes) return;
 
-  // 캔버스 초기화
   ctx.fillStyle = 'white';
   ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-  // strokes를 캔버스에 맞게 스케일링
-  const { scale, offsetX, offsetY } = calculateStrokeScale(
-    strokes,
-    canvas.width,
-    canvas.height,
-  );
+  // shouldScale일 때만 계산
+  const scaleInfo = shouldScale
+    ? calculateStrokeScale(strokes, canvas.width, canvas.height)
+    : null;
 
-  // 모든 strokes 그리기
   strokes.forEach((stroke) => {
     const [xPoints, yPoints] = stroke.points;
     const [r, g, b] = stroke.color;
 
     ctx.strokeStyle = `rgb(${r}, ${g}, ${b})`;
     ctx.beginPath();
+
     if (xPoints.length > 0) {
-      const { x, y } = transformPoint(
-        xPoints[0],
-        yPoints[0],
-        scale,
-        offsetX,
-        offsetY,
-      );
-      ctx.moveTo(x, y);
-      for (let i = 1; i < xPoints.length; i++) {
-        const transformed = transformPoint(
-          xPoints[i],
-          yPoints[i],
+      if (shouldScale && scaleInfo) {
+        const { scale, offsetX, offsetY } = scaleInfo;
+        const { x, y } = transformPoint(
+          xPoints[0],
+          yPoints[0],
           scale,
           offsetX,
           offsetY,
         );
-        ctx.lineTo(transformed.x, transformed.y);
+        ctx.moveTo(x, y);
+        for (let i = 1; i < xPoints.length; i++) {
+          const transformed = transformPoint(
+            xPoints[i],
+            yPoints[i],
+            scale,
+            offsetX,
+            offsetY,
+          );
+          ctx.lineTo(transformed.x, transformed.y);
+        }
+      } else {
+        ctx.moveTo(xPoints[0], yPoints[0]);
+        for (let i = 1; i < xPoints.length; i++) {
+          ctx.lineTo(xPoints[i], yPoints[i]);
+        }
       }
     }
     ctx.stroke();

--- a/client/src/features/drawingCanvas/ui/DrawingCanvas.tsx
+++ b/client/src/features/drawingCanvas/ui/DrawingCanvas.tsx
@@ -128,7 +128,7 @@ export const DrawingCanvas = () => {
 
     // strokes 길이가 줄어들 때는 캔버스 다시 그리기 (undo/clear)
     if (strokes.length < strokeCountRef.current) {
-      drawStrokesOnCanvas(canvasRef, ctxRef, strokes);
+      drawStrokesOnCanvas(canvasRef, ctxRef, strokes, false);
     }
 
     strokeCountRef.current = strokes.length;


### PR DESCRIPTION
## 개요

drawStrokesOnCanvas 함수에 shouldScale 옵션을 추가하여 undo 시 발생하던 중복 스케일링 문제를 해결했습니다.


## 관련 이슈

> ex) Closes #12, Fixes #33

-

## 변경 사항
- drawStrokesOnCanvas에 shouldScale 파라미터 추가 (기본값: true)
- shouldScale=false 시 원본 좌표 그대로 사용하도록 분기 처리
- DrawingCanvas에서 undo/clear 복원 시 shouldScale=false로 호출

### 체크리스트

<!-- 리뷰 전에 본인이 확인해야 하는 항목 -->

- [x] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [x] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [x] 주석/변수명 등 가독성을 고려했습니다.
- [x] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [x] API, DB 변경 시 문서화했습니다.
- [x] 새로운 의존성 추가 시 팀과 공유했습니다.

## 테스트 및 검증 내용

> 어떻게 테스트했고, 어떤 결과를 확인했는지 적어주세요.


## AI 활용 점검

> AI를 어떻게 활용했는지 적어주세요.

## 추가 참고 사항

> 리뷰어가 알아야 할 특이사항, 주의사항 등을 적어주세요.

## 스크린샷 / UI 변경 (선택)

> UI가 변경된 경우 스크린샷을 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 캔버스 렌더링 로직을 최적화하여 성능을 개선했습니다.
  * 실행 취소 및 초기화 작업 시 캔버스 재렌더링 처리를 효율화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->