### PR TITLE
[feat] 그림 데이터 저장 추가

### DIFF
--- a/client/src/features/drawingCanvas/ui/DrawingCanvas.tsx
+++ b/client/src/features/drawingCanvas/ui/DrawingCanvas.tsx
@@ -59,10 +59,10 @@ export const DrawingCanvas = () => {
             roomId,
           },
           {
-            '라운드 총 시간': totalRoundTimeSec,
-            '그림 그린 시간': actualDrawingTimeSec.toFixed(2),
-            '대기한 시간': thinkingTimeSec.toFixed(2),
-            '그림 그리기 비율': drawingRatio.toFixed(1),
+            totalRoundTime: totalRoundTimeSec,
+            actualDrawingTime: actualDrawingTimeSec.toFixed(2),
+            waitingTime: thinkingTimeSec.toFixed(2),
+            drawingRatio: drawingRatio.toFixed(1),
           },
         );
       }
@@ -97,6 +97,17 @@ export const DrawingCanvas = () => {
         preprocessedPlayer,
       );
 
+      captureEvent(
+        'Drawing Data',
+        'info',
+        {
+          roomId,
+        },
+        {
+          strokesData: strokes,
+        },
+      );
+
       getSocket().emit(SERVER_EVENTS.USER_DRAWING, {
         roomId,
         strokes,
@@ -122,18 +133,6 @@ export const DrawingCanvas = () => {
         roomId,
         similarity: similarity.similarity,
       });
-
-      captureEvent(
-        'Drawing Data',
-        'info',
-        {
-          round: String(currentRound),
-          roomId,
-        },
-        {
-          '그림 데이터': strokes,
-        },
-      );
     } catch (error) {
       console.error('Failed to calculate/send similarity:', error);
     }


### PR DESCRIPTION
## 개요

> 사용자가 그림을 그린 시간과 그린 strokes 데이터 배열도 sentry로 전송

strokes 배열 자체를 의존성 배열로 주입하면 매번 리렌더링이 일어날 것 같아서 strokesRef로 대체

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 그림 제출 시 유사도 계산 과정 관련 추가 모니터링 로그를 도입하여 문제 추적을 강화했습니다.
  * 로그의 키명을 영어로 표준화하여 추적성과 일관성을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->