### PR TITLE
[hotfix] strokes 데이터 string 형식으로 변경 후 센트리 전송

### DIFF
--- a/client/src/features/drawingCanvas/ui/DrawingCanvas.tsx
+++ b/client/src/features/drawingCanvas/ui/DrawingCanvas.tsx
@@ -104,7 +104,7 @@ export const DrawingCanvas = () => {
           roomId,
         },
         {
-          strokesData: strokes,
+          strokesData: JSON.stringify(strokes),
         },
       );
 


### PR DESCRIPTION
## 개요

stroke가 배열이라 특정 깊이 이후에는 캡쳐를 하지 않는 문제 발생
JSON.stringify로 문자열로 변경 이후 센트리 전송하는 방식으로 변경 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 그리기 데이터 캡처 시 데이터 형식을 개선하여 더 안정적인 전송을 보장합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->