### PR TITLE
[fix] 게임 종료 후 대기 상태로 변환 시 프롬프트 재설정

### DIFF
--- a/server/src/round/round.service.ts
+++ b/server/src/round/round.service.ts
@@ -246,6 +246,10 @@ export class RoundService implements OnModuleInit {
 
     // GAME_END 타이머 취소 (재시작 시 자동 시작 방지)
     await this.timerService.cancelTimer(room.roomId);
+    await this.promptService.resetPromptIds(
+      room.roomId,
+      room.settings.totalRounds,
+    );
 
     room.phase = GamePhase.WAITING;
     room.currentRound = 0;


### PR DESCRIPTION
## 개요

게임 종료 후 대기 상태로 변환 시 프롬프트 재설정

## 관련 이슈

- Closes #171 

## 변경 사항
- `roundService`.`moveWaiting` 
  - `promptService.resetPromptIds` 실행


### 체크리스트


- [x] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [x] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [x] 주석/변수명 등 가독성을 고려했습니다.
- [x] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [x] API, DB 변경 시 문서화했습니다.
- [x] 새로운 의존성 추가 시 팀과 공유했습니다.

## 테스트 및 검증 내용

### 게임 최초 생성 시 `ids: [7, 1, 5]`
<img width="706" height="120" alt="image" src="https://github.com/user-attachments/assets/e075206e-a0c9-4694-b90f-bb25fe9285a3" />

### 재시작 시 `ids: [4, 5, 7]`
<img width="775" height="120" alt="image" src="https://github.com/user-attachments/assets/796d1c81-f961-4f3c-8ba7-df1f6e039805" />


## AI 활용 점검

없습니다

## 추가 참고 사항

> 리뷰어가 알아야 할 특이사항, 주의사항 등을 적어주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 게임 라운드 간 상태 초기화 메커니즘을 개선하여 연속된 게임 세션에서 이전 데이터가 올바르게 정리되도록 하였습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->