### PR TITLE
[fix] 게임 중 혼자 남으면 즉시 종료하는 기능 구현

### DIFF
--- a/server/src/game/game.gateway.ts
+++ b/server/src/game/game.gateway.ts
@@ -148,11 +148,12 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       );
       this.chatGateway.broadcastSystemMessage(room.roomId, leaveMsg);
 
-      // 빈 방이면 삭제 + 채팅 정리
-      if (room.players.length === 0) {
-        await this.roomService.deleteRoom(room.roomId);
-        await this.chatService.clearHistory(room.roomId);
-        return;
+      const { isDeleted } = await this.gameService.handleRoomStateAfterLeave(
+        room.roomId,
+      );
+
+      if (isDeleted) {
+        this.chatService.clearHistory(room.roomId);
       }
 
       this.broadcastMetadata(room);

--- a/server/src/game/game.service.ts
+++ b/server/src/game/game.service.ts
@@ -185,6 +185,26 @@ export class GameService {
     return { room, kickedPlayer };
   }
 
+  async handleRoomStateAfterLeave(roomId: string) {
+    const players = await this.playerService.getPlayers(roomId);
+    const room = await this.roomService.getRoom(roomId);
+
+    if (players.length === 0) {
+      await this.roomService.deleteRoom(roomId);
+      return { isDeleted: true };
+    }
+
+    if (
+      players.length === 1 &&
+      room.phase !== GamePhase.WAITING &&
+      room.phase !== GamePhase.GAME_END
+    ) {
+      await this.roundService.endGame(room);
+    }
+
+    return { isDeleted: false };
+  }
+
   async startPractice() {
     const randomPrompt = await this.promptService.getRandomPrompt();
     return randomPrompt;


### PR DESCRIPTION


## 개요

- 플레이어가 나간 후, handleRoomStateAfterLeave 를 호출해서
- 플레이어가 없으면 방을 삭제하고, 게임 중, 혼자 남으면 즉시 게임을 종료합니다.
## 관련 이슈


- #216 

## 변경 사항

- game.service: handleRoomStateAfterLeave 추가
  - 플레이어 인원 체크
  -  없으면, 방 삭제
  -  게임 중에 혼자 남으면 즉시 게임 종료   

### 체크리스트

<!-- 리뷰 전에 본인이 확인해야 하는 항목 -->

- [x] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [x] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [x] 주석/변수명 등 가독성을 고려했습니다.
- [x] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [x] API, DB 변경 시 문서화했습니다.
- [x] 새로운 의존성 추가 시 팀과 공유했습니다.

## 테스트 및 검증 내용

> 어떻게 테스트했고, 어떤 결과를 확인했는지 적어주세요.

## AI 활용 점검

> AI를 어떻게 활용했는지 적어주세요.

## 추가 참고 사항

> 리뷰어가 알아야 할 특이사항, 주의사항 등을 적어주세요.

## 스크린샷 / UI 변경 (선택)

> UI가 변경된 경우 스크린샷을 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 플레이어가 방을 나올 때 게임 상태 관리를 개선했습니다.
  * 방에 플레이어가 남지 않을 때 방이 올바르게 정리되도록 수정했습니다.
  * 방에 플레이어가 하나 남았을 때 게임 종료 처리를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->