### PR TITLE
[feat] 게임 페이지에서 새로고침/창닫기 방지 기능 추가

### DIFF
--- a/client/src/features/socket/index.ts
+++ b/client/src/features/socket/index.ts
@@ -1,1 +1,2 @@
 export { useGameSocket } from './model/useGameSocket';
+export { useBeforeUnload } from './model/useBeforeUnload';

--- a/client/src/features/socket/model/useBeforeUnload.ts
+++ b/client/src/features/socket/model/useBeforeUnload.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+/**
+ * 게임 페이지에서 새로고침/창닫기 시 확인 대화상자를 표시하는 훅
+ * 메인 페이지를 제외한 모든 게임 페이지에서 사용
+ */
+export const useBeforeUnload = () => {
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      // Chrome에서는 returnValue 설정이 필요
+      e.returnValue = '';
+      return '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
+};

--- a/client/src/pages/game/Game.tsx
+++ b/client/src/pages/game/Game.tsx
@@ -1,5 +1,5 @@
 import { selectPhase, useGameStore } from '@/entities/gameRoom';
-import { useGameSocket } from '@/features/socket';
+import { useGameSocket, useBeforeUnload } from '@/features/socket';
 import { OverlayModal } from '@/shared/ui';
 import { Drawing } from '@/widgets/drawing';
 import { Prompt } from '@/widgets/prompt';
@@ -23,6 +23,7 @@ const GAME_PHASE_COMPONENT_MAP: Record<Phase, React.FC> = {
 const Game = () => {
   const navigate = useNavigate();
   useGameSocket();
+  useBeforeUnload();
   const phase = useGameStore(selectPhase);
   const alertMessage = useGameStore((state) => state.alertMessage);
   const setAlertMessage = useGameStore((state) => state.setAlertMessage);


### PR DESCRIPTION
## 개요

> 게임 페이지 진입 시 beforeunload 이벤트를 통해 확인 대화상자를 표시하여 실수로 게임을 이탈하는 것을 방지합니다.

## 관련 이슈

- Closes #260

## 변경 사항

### 신규 기능
- **useBeforeUnload 훅 추가**: 게임 페이지에서 새로고침(F5) 또는 창닫기 시 브라우저 확인 대화상자 표시
- Game 컴포넌트에서 해당 훅 사용

### 변경된 파일
- `client/src/features/socket/model/useBeforeUnload.ts` (신규)
- `client/src/features/socket/index.ts`
- `client/src/pages/game/Game.tsx`

### 체크리스트

- [x] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [x] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [x] 주석/변수명 등 가독성을 고려했습니다.
- [x] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [x] API, DB 변경 시 문서화했습니다.
- [x] 새로운 의존성 추가 시 팀과 공유했습니다.

## 테스트 및 검증 내용

> - 게임 페이지 진입 후 새로고침(F5) 시 확인 대화상자 표시 확인
> - 게임 페이지에서 창닫기(X 버튼) 시 확인 대화상자 표시 확인
> - 메인 페이지에서는 확인 대화상자 없이 정상 이탈 확인

## AI 활용 점검

> Claude Code를 활용하여 useBeforeUnload 훅 구현 및 Game 컴포넌트 연동

## 추가 참고 사항

> - `beforeunload` 이벤트는 브라우저 기본 확인 대화상자를 사용하므로 커스텀 메시지는 표시되지 않습니다 (보안상 브라우저 정책)
> - Chrome에서는 `e.returnValue = ''` 설정이 필요합니다

## 스크린샷 / UI 변경 (선택)

> 브라우저 기본 확인 대화상자 표시 (예: "사이트에서 나가시겠습니까?")


<img width="1000" alt="image" src="https://github.com/user-attachments/assets/5f34f214-e784-43d7-ab64-ba287858d3ac" />
