### PR TITLE
[fix] Windows에서 lefthook commit-msg 훅 bash 문법 오류 수정

### DIFF
--- a/.lefthook/commit-msg/check-convention.sh
+++ b/.lefthook/commit-msg/check-convention.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+MSG_FILE="$1"
+MSG=$(cat "$MSG_FILE")
+
+# 빈 메시지 무시
+if [ -z "$MSG" ]; then
+  exit 0
+fi
+
+# Merge 커밋 무시
+if echo "$MSG" | grep -q "^Merge"; then
+  exit 0
+fi
+
+# 커밋 메시지 형식 검사: type(scope): message 또는 type: message
+# 허용되는 타입 (! 접두사 포함)
+if ! echo "$MSG" | grep -qE "^(!BREAKING CHANGE|!HOTFIX|feat|fix|style|design|refactor|docs|chore|lint|deploy|test|rename|remove|type|comment|build|ci|perf)(\([a-z]+\))?:[[:space:]].+"; then
+  echo "❌ 커밋 메시지 형식이 올바르지 않습니다!"
+  echo ""
+  echo "올바른 형식: type(scope): message"
+  echo "scope는 선택사항입니다 (fe, be 등)"
+  echo ""
+  echo "허용되는 타입:"
+  echo "  - feat: 새로운 기능 추가"
+  echo "  - fix: 버그 수정"
+  echo "  - style: 코드 포맷 변경"
+  echo "  - design: CSS 등 UI 변경"
+  echo "  - refactor: 코드 리팩토링"
+  echo "  - docs: 문서 수정"
+  echo "  - chore: 빌드/설정 작업"
+  echo "  - lint: ESLint 설정/에러 수정"
+  echo "  - deploy: 빌드 및 배포 작업"
+  echo "  - test: 테스트 추가/수정"
+  echo "  - rename: 파일/폴더명 변경"
+  echo "  - remove: 파일 삭제"
+  echo "  - type: 타입 정의 수정"
+  echo "  - comment: 주석 추가/변경"
+  echo "  - build: 빌드 시스템 변경"
+  echo "  - ci: CI 설정 변경"
+  echo "  - perf: 성능 개선"
+  echo "  - !HOTFIX: 긴급 버그 수정"
+  echo "  - !BREAKING CHANGE: 큰 API 변경"
+  echo ""
+  echo "예시: feat(fe): 회원가입 이메일 인증 추가"
+  echo "예시: fix: 로그인 리다이렉트 오류 수정"
+  exit 1
+fi

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -25,52 +25,6 @@ pre-commit:
 
 # Commit message 검증
 commit-msg:
-  commands:
-    check-convention:
-      run: |
-        MSG_FILE="{1}"
-        MSG=$(cat "$MSG_FILE")
-
-        # 빈 메시지 무시
-        if [ -z "$MSG" ]; then
-          exit 0
-        fi
-
-        # Merge 커밋 무시
-        if echo "$MSG" | grep -q "^Merge"; then
-          exit 0
-        fi
-
-        # 커밋 메시지 형식 검사: type(scope): message 또는 type: message
-        # 허용되는 타입 (! 접두사 포함)
-        if ! echo "$MSG" | grep -qE "^(!BREAKING CHANGE|!HOTFIX|feat|fix|style|design|refactor|docs|chore|lint|deploy|test|rename|remove|type|comment|build|ci|perf)(\([a-z]+\))?:\s.+"; then
-          echo "❌ 커밋 메시지 형식이 올바르지 않습니다!"
-          echo ""
-          echo "올바른 형식: type(scope): message"
-          echo "scope는 선택사항입니다 (fe, be 등)"
-          echo ""
-          echo "허용되는 타입:"
-          echo "  - feat: 새로운 기능 추가"
-          echo "  - fix: 버그 수정"
-          echo "  - style: 코드 포맷 변경"
-          echo "  - design: CSS 등 UI 변경"
-          echo "  - refactor: 코드 리팩토링"
-          echo "  - docs: 문서 수정"
-          echo "  - chore: 빌드/설정 작업"
-          echo "  - lint: ESLint 설정/에러 수정"
-          echo "  - deploy: 빌드 및 배포 작업"
-          echo "  - test: 테스트 추가/수정"
-          echo "  - rename: 파일/폴더명 변경"
-          echo "  - remove: 파일 삭제"
-          echo "  - type: 타입 정의 수정"
-          echo "  - comment: 주석 추가/변경"
-          echo "  - build: 빌드 시스템 변경"
-          echo "  - ci: CI 설정 변경"
-          echo "  - perf: 성능 개선"
-          echo "  - !HOTFIX: 긴급 버그 수정"
-          echo "  - !BREAKING CHANGE: 큰 API 변경"
-          echo ""
-          echo "예시: feat(fe): 회원가입 이메일 인증 추가"
-          echo "예시: fix: 로그인 리다이렉트 오류 수정"
-          exit 1
-        fi
+  scripts:
+    "check-convention.sh":
+      runner: bash


### PR DESCRIPTION
## 어떤 문제였나요?

Windows에서 커밋을 하면 아래와 같은 오류가 발생했어요.

```
syntax error near unexpected token '('
```

커밋 메시지 검사 스크립트가 **bash 문법**으로 작성되어 있었는데, Windows에서 lefthook이 이를 bash가 아닌 **sh**로 실행했기 때문이에요.

sh는 \s, \(의 역슬래시를 정규식이 아닌 shell 문법으로 먼저 해석해버려서 grep에 잘못된 패턴이 전달돼요.



컴퓨터에게 명령을 내리는 "언어"(shell)는 종류가 여러 개 있어요.
- **bash** - Mac/Linux 기본 shell, 기능이 풍부
- **sh** - bash보다 오래된 단순한 버전
- **cmd** - Windows 기본 shell, 완전히 다른 언어

스크립트는 bash 문법(`if !`, `grep -qE`, `\s`)으로 쓰여 있었는데, lefthook이 "bash로 실행해"라는 명시가 없어서 Windows에서 sh를 선택해버린 거예요.


<br />

## 어떻게 해결했나요?

핵심 해결책은 runner: bash 명시예요. lefthook에 "무조건 bash로 실행해!"라고 알려주는 옵션이에요.

그런데 이 runner: 옵션은 lefthook의 scripts 방식에서만 사용할 수 있어요. 기존처럼 lefthook.yml 안에 스크립트를 직접 쓰는 인라인 방식(run:)에서는 지원하지 않아요.
```
# ❌ 인라인 방식 - runner: 옵션 사용 불가
commands:
  check-convention:
    run: |
      MSG=$(cat "$1")
      ...
```

그래서 스크립트를 .lefthook/commit-msg/check-convention.sh 파일로 분리하고, runner: bash를 명시했어요.
```
# ✅ scripts 방식 - runner: 옵션 사용 가능
commit-msg:
  scripts:
    "check-convention.sh":
      runner: bash   # ← "무조건 bash로 실행해!"
```

이제 Windows든 Mac이든 항상 bash로 실행되어 동일하게 동작해요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- 커밋 메시지 검증 시스템이 도입되었습니다. 모든 커밋 메시지는 정해진 형식(type(scope)?: message)을 준수해야 하며, 규칙을 위반할 경우 안내 메시지와 함께 거부됩니다. 허용된 타입에는 breaking changes를 나타내는 접두사도 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->