### PR TITLE
[feat] 메인(대시보드)화면 UI 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ docs
 /playwright/.cache/
 /playwright/.auth/
 .playwright-mcp/
+
+# App-in-Toss build file
+we-are-all-da-vinci.ait

--- a/client-toss/package.json
+++ b/client-toss/package.json
@@ -20,6 +20,7 @@
     "@apps-in-toss/web-framework": "^2.0.9",
     "@emotion/react": "^11.14.0",
     "@toss/shared": "workspace:*",
+    "@toss/tds-colors": "^0.1.0",
     "@toss/tds-mobile": "^2.3.0",
     "@toss/tds-mobile-ait": "^2.3.0",
     "clsx": "^2.1.1",

--- a/client-toss/scripts/dev.js
+++ b/client-toss/scripts/dev.js
@@ -2,7 +2,9 @@ import { networkInterfaces } from "os";
 import { spawn } from "child_process";
 
 function getLocalIP() {
-  for (const iface of Object.values(networkInterfaces())) {
+  for (const [name, iface] of Object.entries(networkInterfaces())) {
+    const lowerName = name.toLowerCase();
+    if (lowerName.includes("vethernet") || lowerName.includes("wsl")) continue;
     for (const net of iface) {
       if (net.family === "IPv4" && !net.internal) return net.address;
     }
@@ -11,6 +13,7 @@ function getLocalIP() {
 }
 
 const host = getLocalIP();
+console.log(`host: ${host}`);
 
 const proc = spawn("granite", ["dev"], {
   env: { ...process.env, WEBVIEW_HOST: host },

--- a/client-toss/scripts/qa-checks/ad-integration.ts
+++ b/client-toss/scripts/qa-checks/ad-integration.ts
@@ -35,12 +35,17 @@ export async function run(): Promise<CheckResult> {
   }
 
   // 2. 소스에서 제3자 광고 SDK import 스캔
-  const files = execSync('find src -name "*.ts" -o -name "*.tsx"', {
+  const findCommand =
+    process.platform === "win32"
+      ? `powershell -Command "Get-ChildItem -Path src -Recurse -Include '*.ts','*.tsx' | ForEach-Object { $_.FullName.Substring($PWD.Path.Length + 1).Replace('\\', '/') }"`
+      : 'find src -name "*.ts" -o -name "*.tsx"';
+
+  const files = execSync(findCommand, {
     cwd: ROOT,
     encoding: "utf-8",
   })
     .trim()
-    .split("\n")
+    .split(/\r?\n/)
     .filter(Boolean);
 
   for (const relPath of files) {

--- a/client-toss/scripts/qa-checks/dark-pattern.ts
+++ b/client-toss/scripts/qa-checks/dark-pattern.ts
@@ -13,12 +13,17 @@ export async function run(): Promise<CheckResult> {
   const details: string[] = [];
   let status: CheckResult["status"] = "pass";
 
-  const files = execSync('find src -name "*.tsx"', {
+  const findCommand =
+    process.platform === "win32"
+      ? `powershell -Command "Get-ChildItem -Path src -Recurse -Filter '*.tsx' | ForEach-Object { $_.FullName.Substring($PWD.Path.Length + 1).Replace('\\', '/') }"`
+      : 'find src -name "*.tsx"';
+
+  const files = execSync(findCommand, {
     cwd: ROOT,
     encoding: "utf-8",
   })
     .trim()
-    .split("\n")
+    .split(/\r?\n/)
     .filter(Boolean);
 
   for (const relPath of files) {

--- a/client-toss/scripts/qa-checks/external-links.ts
+++ b/client-toss/scripts/qa-checks/external-links.ts
@@ -30,12 +30,17 @@ export async function run(): Promise<CheckResult> {
   const details: string[] = [];
   let status: CheckResult["status"] = "pass";
 
-  const files = execSync('find src -name "*.ts" -o -name "*.tsx"', {
+  const findCommand =
+    process.platform === "win32"
+      ? `powershell -Command "Get-ChildItem -Path src -Recurse -Include '*.ts','*.tsx' | ForEach-Object { $_.FullName.Substring($PWD.Path.Length + 1).Replace('\\', '/') }"`
+      : 'find src -name "*.ts" -o -name "*.tsx"';
+
+  const files = execSync(findCommand, {
     cwd: ROOT,
     encoding: "utf-8",
   })
     .trim()
-    .split("\n")
+    .split(/\r?\n/)
     .filter(Boolean);
 
   for (const relPath of files) {

--- a/client-toss/scripts/qa-checks/tds-usage.ts
+++ b/client-toss/scripts/qa-checks/tds-usage.ts
@@ -32,12 +32,17 @@ export async function run(): Promise<CheckResult> {
   const details: string[] = [];
   let status: CheckResult["status"] = "pass";
 
-  const files = execSync('find src -name "*.tsx"', {
+  const findCommand =
+    process.platform === "win32"
+      ? `powershell -Command "Get-ChildItem -Path src -Recurse -Filter '*.tsx' | ForEach-Object { $_.FullName.Substring($PWD.Path.Length + 1).Replace('\\', '/') }"`
+      : 'find src -name "*.tsx"';
+
+  const files = execSync(findCommand, {
     cwd: ROOT,
     encoding: "utf-8",
   })
     .trim()
-    .split("\n")
+    .split(/\r?\n/)
     .filter(Boolean);
 
   for (const relPath of files) {

--- a/client-toss/scripts/qa-checks/ux-writing.ts
+++ b/client-toss/scripts/qa-checks/ux-writing.ts
@@ -54,12 +54,17 @@ export async function run(): Promise<CheckResult> {
   const details: string[] = [];
   let status: CheckResult["status"] = "pass";
 
-  const files = execSync('find src -name "*.tsx" -o -name "*.ts"', {
+  const findCommand =
+    process.platform === "win32"
+      ? `powershell -Command "Get-ChildItem -Path src -Recurse -Include '*.ts','*.tsx' | ForEach-Object { $_.FullName.Substring($PWD.Path.Length + 1).Replace('\\', '/') }"`
+      : 'find src -name "*.tsx" -o -name "*.ts"';
+
+  const files = execSync(findCommand, {
     cwd: ROOT,
     encoding: "utf-8",
   })
     .trim()
-    .split("\n")
+    .split(/\r?\n/)
     .filter(Boolean);
 
   for (const relPath of files) {

--- a/client-toss/src/app/config/router.tsx
+++ b/client-toss/src/app/config/router.tsx
@@ -1,3 +1,4 @@
+import { DashboardView } from "@/views/dashboard";
 import { Drawing } from "@/views/drawing";
 import { HomeView } from "@/views/home";
 import { Memorize } from "@/views/memorize";
@@ -20,5 +21,9 @@ export const router = createBrowserRouter([
   {
     path: "/submitted",
     element: <SubmittedView />,
+  },
+  {
+    path: "/dashboard",
+    element: <DashboardView />,
   },
 ]);

--- a/client-toss/src/entities/myScoreCard/index.ts
+++ b/client-toss/src/entities/myScoreCard/index.ts
@@ -1,0 +1,1 @@
+export { default as MyScoreCard } from "./ui/MyScoreCard";

--- a/client-toss/src/entities/myScoreCard/ui/MyScoreCard.tsx
+++ b/client-toss/src/entities/myScoreCard/ui/MyScoreCard.tsx
@@ -4,7 +4,7 @@ import { Paragraph, Post } from "@toss/tds-mobile";
 
 const MyScoreCard = () => {
   return (
-    <div className="flex flex-col w-full items-center px-6 gap-3">
+    <div className="flex flex-col w-full items-center px-(--page-px) gap-3">
       {/* 내 그림 */}
       <div
         className="mx-(--card-mx) mt-2 rounded-2xl p-3"

--- a/client-toss/src/entities/myScoreCard/ui/MyScoreCard.tsx
+++ b/client-toss/src/entities/myScoreCard/ui/MyScoreCard.tsx
@@ -1,0 +1,38 @@
+import { ScoreDetailCard } from "@/entities/scoreDetailCard";
+import { colors } from "@toss/tds-colors";
+import { Paragraph, Post } from "@toss/tds-mobile";
+
+const MyScoreCard = () => {
+  return (
+    <div className="flex flex-col w-full items-center px-6 gap-3">
+      {/* 내 그림 */}
+      <div
+        className="mx-(--card-mx) mt-2 rounded-2xl p-3"
+        style={{ backgroundColor: colors.grey100 }}
+      >
+        <img
+          src="https://placehold.co/400x400"
+          alt="나의 그림"
+          className="w-full rounded-xl bg-white object-contain shadow-sm"
+        />
+      </div>
+      <div
+        className="h-[160px] w-full"
+        style={{ backgroundColor: colors.grey100 }}
+      >
+        그래프 영역
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <Paragraph typography="t1">
+          <Paragraph.Text fontWeight="bold">77.99</Paragraph.Text>
+          <Paragraph.Text typography="t5">점</Paragraph.Text>
+        </Paragraph>
+        <Post.Paragraph>현재 18,239위</Post.Paragraph>
+      </div>
+
+      <ScoreDetailCard />
+    </div>
+  );
+};
+
+export default MyScoreCard;

--- a/client-toss/src/entities/scoreDetailCard/index.ts
+++ b/client-toss/src/entities/scoreDetailCard/index.ts
@@ -1,0 +1,1 @@
+export { default as ScoreDetailCard } from "./ui/ScoreDetailCard";

--- a/client-toss/src/entities/scoreDetailCard/ui/ScoreDetailCard.tsx
+++ b/client-toss/src/entities/scoreDetailCard/ui/ScoreDetailCard.tsx
@@ -1,0 +1,64 @@
+import { colors } from "@toss/tds-colors";
+import { Border, Paragraph } from "@toss/tds-mobile";
+
+const ScoreDetailCard = () => {
+  return (
+    <div className="w-full flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col">
+          <Paragraph typography="t5">
+            <Paragraph.Text fontWeight="medium">선 유사도</Paragraph.Text>
+          </Paragraph>
+          <Paragraph typography="t6">
+            <Paragraph.Text color={colors.grey500}>
+              선의 개수가 유사해요
+            </Paragraph.Text>
+          </Paragraph>
+        </div>
+        <Paragraph typography="t5">
+          <Paragraph.Text fontWeight="medium" color={colors.blue500}>
+            +80.55점
+          </Paragraph.Text>
+        </Paragraph>
+      </div>
+      <Border variant="full" />
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col">
+          <Paragraph typography="t5">
+            <Paragraph.Text fontWeight="medium">형태 유사도</Paragraph.Text>
+          </Paragraph>
+          <Paragraph typography="t6">
+            <Paragraph.Text color={colors.grey500}>
+              전체 그림의 형태가 제시 그림과 달라요
+            </Paragraph.Text>
+          </Paragraph>
+        </div>
+        <Paragraph typography="t5">
+          <Paragraph.Text fontWeight="medium" color={colors.blue500}>
+            +80.55점
+          </Paragraph.Text>
+        </Paragraph>
+      </div>
+      <Border variant="full" />
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col">
+          <Paragraph typography="t5">
+            <Paragraph.Text fontWeight="medium">패널티</Paragraph.Text>
+          </Paragraph>
+          <Paragraph typography="t6">
+            <Paragraph.Text color={colors.grey500}>
+              실수 없이 깔끔하게 그렸어요
+            </Paragraph.Text>
+          </Paragraph>
+        </div>
+        <Paragraph typography="t5">
+          <Paragraph.Text fontWeight="medium" color={colors.red500}>
+            -10.00점
+          </Paragraph.Text>
+        </Paragraph>
+      </div>
+    </div>
+  );
+};
+
+export default ScoreDetailCard;

--- a/client-toss/src/views/dashboard/index.ts
+++ b/client-toss/src/views/dashboard/index.ts
@@ -1,0 +1,1 @@
+export { default as DashboardView } from "./ui/DashboardView";

--- a/client-toss/src/views/dashboard/ui/DashboardView.tsx
+++ b/client-toss/src/views/dashboard/ui/DashboardView.tsx
@@ -1,12 +1,6 @@
-import {
-  Border,
-  Button,
-  Paragraph,
-  Post,
-  TextButton,
-  Top,
-} from "@toss/tds-mobile";
+import { Button, Paragraph, Post, TextButton, Top } from "@toss/tds-mobile";
 import { colors } from "@toss/tds-colors";
+import { ScoreDetailCard } from "@/entities/scoreDetailCard";
 
 const DashboardView = () => {
   return (
@@ -19,9 +13,10 @@ const DashboardView = () => {
             <Top.SubtitleParagraph>명예의 전당</Top.SubtitleParagraph>
           }
         />
-        <div className="flex w-full flex-col items-center gap-4">
+        <div className="flex w-full flex-col items-center gap-4 px-6">
+          {/* 랭킹 TOP3 */}
           <div
-            className="h-[205px] w-full"
+            className="h-[205px] w-full rounded-xl"
             style={{ backgroundColor: colors.grey100 }}
           >
             TOP3
@@ -34,7 +29,7 @@ const DashboardView = () => {
       {/* 나의 결과 영역 */}
       <Top title={<Top.TitleParagraph>나의 결과</Top.TitleParagraph>} />
       {/* 슬라이드할 부분 */}
-      <div className="flex flex-col w-full items-center">
+      <div className="flex flex-col w-full items-center px-6 gap-3">
         {/* 내 그림 */}
         <div
           className="mx-(--card-mx) mt-2 rounded-2xl p-3"
@@ -52,76 +47,26 @@ const DashboardView = () => {
         >
           그래프 영역
         </div>
-        <Paragraph typography="t1">
-          <Paragraph.Text fontWeight="bold">77.99</Paragraph.Text>
-          <Paragraph.Text typography="t5">점</Paragraph.Text>
-        </Paragraph>
-        <Post.Paragraph>현재 18,239위</Post.Paragraph>
-
-        <div className="w-full">
-          <div className="flex items-center justify-between">
-            <div className="flex flex-col">
-              <Paragraph typography="t5">
-                <Paragraph.Text fontWeight="medium">선 유사도</Paragraph.Text>
-              </Paragraph>
-              <Paragraph typography="t6">
-                <Paragraph.Text color={colors.grey500}>
-                  선의 개수가 유사해요
-                </Paragraph.Text>
-              </Paragraph>
-            </div>
-            <Paragraph typography="t5">
-              <Paragraph.Text fontWeight="medium" color={colors.blue500}>
-                +80.55점
-              </Paragraph.Text>
-            </Paragraph>
-          </div>
-          <Border variant="full" />
-          <div className="flex items-center justify-between">
-            <div className="flex flex-col">
-              <Paragraph typography="t5">
-                <Paragraph.Text fontWeight="medium">형태 유사도</Paragraph.Text>
-              </Paragraph>
-              <Paragraph typography="t6">
-                <Paragraph.Text color={colors.grey500}>
-                  전체 그림의 형태가 제시 그림과 달라요
-                </Paragraph.Text>
-              </Paragraph>
-            </div>
-            <Paragraph typography="t5">
-              <Paragraph.Text fontWeight="medium" color={colors.blue500}>
-                +80.55점
-              </Paragraph.Text>
-            </Paragraph>
-          </div>
-          <Border variant="full" />
-          <div className="flex items-center justify-between">
-            <div className="flex flex-col">
-              <Paragraph typography="t5">
-                <Paragraph.Text fontWeight="medium">패널티</Paragraph.Text>
-              </Paragraph>
-              <Paragraph typography="t6">
-                <Paragraph.Text color={colors.grey500}>
-                  실수 없이 깔끔하게 그렸어요
-                </Paragraph.Text>
-              </Paragraph>
-            </div>
-            <Paragraph typography="t5">
-              <Paragraph.Text fontWeight="medium" color={colors.red500}>
-                -10.00점
-              </Paragraph.Text>
-            </Paragraph>
-          </div>
+        <div className="flex flex-col items-center gap-1">
+          <Paragraph typography="t1">
+            <Paragraph.Text fontWeight="bold">77.99</Paragraph.Text>
+            <Paragraph.Text typography="t5">점</Paragraph.Text>
+          </Paragraph>
+          <Post.Paragraph>현재 18,239위</Post.Paragraph>
         </div>
+
+        <ScoreDetailCard />
       </div>
 
       {/* 하단 버튼 */}
-      <Button color="primary" display="block">
-        한번 더 참여하고 포인트 받기
-      </Button>
-      <Button color="primary" display="block" variant="weak">
-        공유하고 포인트 받기
-      </Button>
+      <div className="px-6 flex flex-col gap-3 mt-9">
+        <Button color="primary" display="block">
+          한번 더 참여하고 포인트 받기
+        </Button>
+        <Button color="primary" display="block" variant="weak">
+          공유하고 포인트 받기
+        </Button>
+      </div>
     </div>
   );
 };

--- a/client-toss/src/views/dashboard/ui/DashboardView.tsx
+++ b/client-toss/src/views/dashboard/ui/DashboardView.tsx
@@ -1,0 +1,129 @@
+import {
+  Border,
+  Button,
+  Paragraph,
+  Post,
+  TextButton,
+  Top,
+} from "@toss/tds-mobile";
+import { colors } from "@toss/tds-colors";
+
+const DashboardView = () => {
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      {/* 랭킹 영역 */}
+      <div>
+        <Top
+          title={<Top.TitleParagraph>오늘의 다빈치</Top.TitleParagraph>}
+          subtitleBottom={
+            <Top.SubtitleParagraph>명예의 전당</Top.SubtitleParagraph>
+          }
+        />
+        <div className="flex w-full flex-col items-center gap-4">
+          <div
+            className="h-[205px] w-full"
+            style={{ backgroundColor: colors.grey100 }}
+          >
+            TOP3
+          </div>
+          <TextButton size="small" variant="arrow">
+            TOP 100 랭킹 보러가기
+          </TextButton>
+        </div>
+      </div>
+      {/* 나의 결과 영역 */}
+      <Top title={<Top.TitleParagraph>나의 결과</Top.TitleParagraph>} />
+      {/* 슬라이드할 부분 */}
+      <div className="flex flex-col w-full items-center">
+        {/* 내 그림 */}
+        <div
+          className="mx-(--card-mx) mt-2 rounded-2xl p-3"
+          style={{ backgroundColor: colors.grey100 }}
+        >
+          <img
+            src="https://placehold.co/400x400"
+            alt="나의 그림"
+            className="w-full rounded-xl bg-white object-contain shadow-sm"
+          />
+        </div>
+        <div
+          className="h-[160px] w-full"
+          style={{ backgroundColor: colors.grey100 }}
+        >
+          그래프 영역
+        </div>
+        <Paragraph typography="t1">
+          <Paragraph.Text fontWeight="bold">77.99</Paragraph.Text>
+          <Paragraph.Text typography="t5">점</Paragraph.Text>
+        </Paragraph>
+        <Post.Paragraph>현재 18,239위</Post.Paragraph>
+
+        <div className="w-full">
+          <div className="flex items-center justify-between">
+            <div className="flex flex-col">
+              <Paragraph typography="t5">
+                <Paragraph.Text fontWeight="medium">선 유사도</Paragraph.Text>
+              </Paragraph>
+              <Paragraph typography="t6">
+                <Paragraph.Text color={colors.grey500}>
+                  선의 개수가 유사해요
+                </Paragraph.Text>
+              </Paragraph>
+            </div>
+            <Paragraph typography="t5">
+              <Paragraph.Text fontWeight="medium" color={colors.blue500}>
+                +80.55점
+              </Paragraph.Text>
+            </Paragraph>
+          </div>
+          <Border variant="full" />
+          <div className="flex items-center justify-between">
+            <div className="flex flex-col">
+              <Paragraph typography="t5">
+                <Paragraph.Text fontWeight="medium">형태 유사도</Paragraph.Text>
+              </Paragraph>
+              <Paragraph typography="t6">
+                <Paragraph.Text color={colors.grey500}>
+                  전체 그림의 형태가 제시 그림과 달라요
+                </Paragraph.Text>
+              </Paragraph>
+            </div>
+            <Paragraph typography="t5">
+              <Paragraph.Text fontWeight="medium" color={colors.blue500}>
+                +80.55점
+              </Paragraph.Text>
+            </Paragraph>
+          </div>
+          <Border variant="full" />
+          <div className="flex items-center justify-between">
+            <div className="flex flex-col">
+              <Paragraph typography="t5">
+                <Paragraph.Text fontWeight="medium">패널티</Paragraph.Text>
+              </Paragraph>
+              <Paragraph typography="t6">
+                <Paragraph.Text color={colors.grey500}>
+                  실수 없이 깔끔하게 그렸어요
+                </Paragraph.Text>
+              </Paragraph>
+            </div>
+            <Paragraph typography="t5">
+              <Paragraph.Text fontWeight="medium" color={colors.red500}>
+                -10.00점
+              </Paragraph.Text>
+            </Paragraph>
+          </div>
+        </div>
+      </div>
+
+      {/* 하단 버튼 */}
+      <Button color="primary" display="block">
+        한번 더 참여하고 포인트 받기
+      </Button>
+      <Button color="primary" display="block" variant="weak">
+        공유하고 포인트 받기
+      </Button>
+    </div>
+  );
+};
+
+export default DashboardView;

--- a/client-toss/src/views/dashboard/ui/DashboardView.tsx
+++ b/client-toss/src/views/dashboard/ui/DashboardView.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import { Button, TextButton, Top } from "@toss/tds-mobile";
 import { colors } from "@toss/tds-colors";
 import { MyScoreCard } from "@/entities/myScoreCard";
+import { BannerAd } from "@/shared/ui/bannerAd";
 
 const CARD_COUNT = 3;
 
@@ -26,7 +27,7 @@ const DashboardView = () => {
             <Top.SubtitleParagraph>명예의 전당</Top.SubtitleParagraph>
           }
         />
-        <div className="flex w-full flex-col items-center gap-4 px-6">
+        <div className="flex w-full flex-col items-center gap-4 px-(--page-px)">
           {/* 랭킹 TOP3 */}
           <div
             className="h-[205px] w-full rounded-xl"
@@ -70,8 +71,10 @@ const DashboardView = () => {
         ))}
       </div>
 
+      <BannerAd adGroupId="ait-ad-test-banner-id" className="mt-3 mb-3" />
+
       {/* 하단 버튼 */}
-      <div className="px-6 flex flex-col gap-3 mt-9">
+      <div className="px-(--page-px) flex flex-col gap-3">
         <Button color="primary" display="block">
           한번 더 참여하고 포인트 받기
         </Button>

--- a/client-toss/src/views/dashboard/ui/DashboardView.tsx
+++ b/client-toss/src/views/dashboard/ui/DashboardView.tsx
@@ -1,8 +1,21 @@
-import { Button, Paragraph, Post, TextButton, Top } from "@toss/tds-mobile";
+import { useRef, useState } from "react";
+import { Button, TextButton, Top } from "@toss/tds-mobile";
 import { colors } from "@toss/tds-colors";
-import { ScoreDetailCard } from "@/entities/scoreDetailCard";
+import { MyScoreCard } from "@/entities/myScoreCard";
+
+const CARD_COUNT = 3;
 
 const DashboardView = () => {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const sliderRef = useRef<HTMLDivElement>(null);
+
+  const handleScroll = () => {
+    const slider = sliderRef.current;
+    if (!slider) return;
+    const index = Math.round(slider.scrollLeft / slider.clientWidth);
+    setActiveIndex(index);
+  };
+
   return (
     <div className="min-h-0 flex-1 overflow-y-auto">
       {/* 랭킹 영역 */}
@@ -26,36 +39,35 @@ const DashboardView = () => {
           </TextButton>
         </div>
       </div>
+
       {/* 나의 결과 영역 */}
       <Top title={<Top.TitleParagraph>나의 결과</Top.TitleParagraph>} />
-      {/* 슬라이드할 부분 */}
-      <div className="flex flex-col w-full items-center px-6 gap-3">
-        {/* 내 그림 */}
-        <div
-          className="mx-(--card-mx) mt-2 rounded-2xl p-3"
-          style={{ backgroundColor: colors.grey100 }}
-        >
-          <img
-            src="https://placehold.co/400x400"
-            alt="나의 그림"
-            className="w-full rounded-xl bg-white object-contain shadow-sm"
-          />
-        </div>
-        <div
-          className="h-[160px] w-full"
-          style={{ backgroundColor: colors.grey100 }}
-        >
-          그래프 영역
-        </div>
-        <div className="flex flex-col items-center gap-1">
-          <Paragraph typography="t1">
-            <Paragraph.Text fontWeight="bold">77.99</Paragraph.Text>
-            <Paragraph.Text typography="t5">점</Paragraph.Text>
-          </Paragraph>
-          <Post.Paragraph>현재 18,239위</Post.Paragraph>
-        </div>
 
-        <ScoreDetailCard />
+      {/* 인디케이터 */}
+      <div className="flex justify-center gap-2 py-4">
+        {Array.from({ length: CARD_COUNT }).map((_, i) => (
+          <div
+            key={i}
+            className="h-2 w-2 rounded-full transition-colors duration-200"
+            style={{
+              backgroundColor:
+                i === activeIndex ? colors.blue500 : colors.grey100,
+            }}
+          />
+        ))}
+      </div>
+      {/* 슬라이드할 부분 */}
+      <div
+        ref={sliderRef}
+        className="flex snap-x snap-mandatory overflow-x-scroll"
+        style={{ scrollbarWidth: "none" }}
+        onScroll={handleScroll}
+      >
+        {Array.from({ length: CARD_COUNT }).map((_, i) => (
+          <div key={i} className="w-full shrink-0 snap-start snap-always">
+            <MyScoreCard />
+          </div>
+        ))}
       </div>
 
       {/* 하단 버튼 */}

--- a/client-toss/src/views/home/ui/HomeView.tsx
+++ b/client-toss/src/views/home/ui/HomeView.tsx
@@ -20,6 +20,11 @@ const HomeView = () => {
           제출 완료 화면으로 이동
         </Button>
       </Link>
+      <Link to="/dashboard">
+        <Button size="large" display="block">
+          대시보드 화면으로 이동
+        </Button>
+      </Link>
     </div>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       '@toss/shared':
         specifier: workspace:*
         version: link:../packages/toss-shared
+      '@toss/tds-colors':
+        specifier: ^0.1.0
+        version: 0.1.0
       '@toss/tds-mobile':
         specifier: ^2.3.0
         version: 2.3.0(@emotion/react@11.14.0(@types/react@19.2.3)(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -20611,7 +20614,7 @@ snapshots:
       '@egjs/hammerjs': 2.0.17
       hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
-      lodash: 4.17.23
+      lodash: 4.18.1
       prop-types: 15.8.1
       react: 19.2.3
       react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@19.2.3)


### PR DESCRIPTION
## 개요

- 메인화면(대시보드) 기본 UI 뼈대를 구현했습니다. 랭킹과 그래프 부분은 영역 설정만 해뒀습니다.
- dev.js가 가상IP를 잡는 문제를 수정했습니다.
- QA 자동화 스크립트를 윈도우 파워쉘 환경에서 실행 가능하도록 수정했습니다.

## 관련 이슈

> ex) Closes #12, Fixes #33

- Closes #298 #285 

## 변경 사항

- 색상 가이드 준수를 위한 toss/tds-colors 패키지가 추가되었습니다. pnpm install 해서 사용하세요

### 체크리스트

<!-- 리뷰 전에 본인이 확인해야 하는 항목 -->

- [ ] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [ ] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [ ] 주석/변수명 등 가독성을 고려했습니다.
- [ ] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [ ] API, DB 변경 시 문서화했습니다.
- [ ] 새로운 의존성 추가 시 팀과 공유했습니다.

## 테스트 및 검증 내용

<img width="1702" height="1056" alt="image" src="https://github.com/user-attachments/assets/2f1b4f5a-cb2c-4539-8b0e-e2554d463a1e" />

## AI 활용 점검

- 슬라이드 UI 구현
- QA 스크립트 수정

## 추가 참고 사항

- QA 스크립트 실행 시 빌드가 수행되는데, 이때 생성된 번들 파일(.ait)을 저장소에 올릴 필요는 없는 것 같아서 .gitignore에 추가했습니다.

## 스크린샷 / UI 변경 (선택)

<img width="324" height="1317" alt="image" src="https://github.com/user-attachments/assets/7a5f524c-bc4c-4f6c-9133-c368ba6dca6b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 새로운 대시보드 페이지 추가
  * 사용자의 점수 및 순위 정보를 표시하는 나의 결과 카드 추가
  * 점수 상세 정보(유사도, 패널티)를 표시하는 상세 정보 카드 추가
  * 홈 화면에서 대시보드로 이동할 수 있는 네비게이션 버튼 추가

* **Chores**
  * Windows 플랫폼 호환성 개선
  * 새로운 색상 라이브러리 의존성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->