### PR TITLE
[feat] app-in-toss analytics 활용 모니터링 기능 구현

### DIFF
--- a/client-toss/src/feature/drawing/ui/Toolbar.tsx
+++ b/client-toss/src/feature/drawing/ui/Toolbar.tsx
@@ -2,6 +2,7 @@ import { ConfirmDialog } from "@toss/tds-mobile";
 import clsx from "clsx";
 import { useState } from "react";
 import { MaskedIcon } from "@/shared/ui/maskedIcon";
+import { trackClick } from "@/shared/lib";
 import { ICON_URL } from "../config/icons";
 import { PALETTE_COLORS } from "../config/colors";
 
@@ -15,6 +16,7 @@ const Toolbar = () => {
   const [isResetDialogOpen, setIsResetDialogOpen] = useState(false);
 
   const handleReset = () => {
+    trackClick("drawing_reset_click");
     // TODO: 캔버스 초기화 로직
     setIsResetDialogOpen(false);
   };
@@ -37,6 +39,7 @@ const Toolbar = () => {
         type="button"
         aria-label="한획 취소"
         className={clsx(toolBtnBase, "active:bg-gray-200")}
+        onClick={() => trackClick("drawing_undo_click")}
       >
         <MaskedIcon src={ICON_URL.refresh} color="var(--color-grey)" />
       </button>

--- a/client-toss/src/feature/login/hooks/useLoginFlow.ts
+++ b/client-toss/src/feature/login/hooks/useLoginFlow.ts
@@ -1,24 +1,20 @@
 import { appLogin } from "@apps-in-toss/web-framework";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { serverTossApi } from "@/shared/api";
+
+const LOGIN_PENDING_KEY = "login_pending";
 
 export const useLoginFlow = () => {
   const navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
 
-  useEffect(() => {
-    if (localStorage.getItem("access_token")) {
-      navigate("/", { replace: true });
-    }
-  }, [navigate]);
-
-  const handleLogin = async () => {
-    if (isLoading) return;
-
+  const performLogin = useCallback(async () => {
     setIsLoading(true);
+    localStorage.setItem(LOGIN_PENDING_KEY, "true");
     try {
       const { authorizationCode, referrer } = await appLogin();
+      localStorage.removeItem(LOGIN_PENDING_KEY);
       const { accessToken } = await serverTossApi.login({
         authorizationCode,
         referrer,
@@ -26,10 +22,27 @@ export const useLoginFlow = () => {
       localStorage.setItem("access_token", accessToken);
       navigate("/", { replace: true });
     } catch (err) {
+      localStorage.removeItem(LOGIN_PENDING_KEY);
       console.error("[login error]", err);
     } finally {
       setIsLoading(false);
     }
+  }, [navigate]);
+
+  useEffect(() => {
+    if (localStorage.getItem("access_token")) {
+      navigate("/", { replace: true });
+      return;
+    }
+    // 약관 동의 후 WebView가 리로드되어 돌아온 경우 자동으로 로그인 재시도
+    if (localStorage.getItem(LOGIN_PENDING_KEY) === "true") {
+      performLogin();
+    }
+  }, [navigate, performLogin]);
+
+  const handleLogin = () => {
+    if (isLoading) return;
+    performLogin();
   };
 
   const handleLogout = async () => {

--- a/client-toss/src/shared/hooks/useImpressionTracking.ts
+++ b/client-toss/src/shared/hooks/useImpressionTracking.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from "react";
+import { trackImpression } from "@/shared/lib";
+
+const useImpressionTracking = <T extends HTMLElement = HTMLDivElement>(
+  logName: string,
+  params?: Record<string, unknown>,
+) => {
+  const ref = useRef<T>(null);
+  const logNameRef = useRef(logName);
+  const paramsRef = useRef(params);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          trackImpression(logNameRef.current, paramsRef.current);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.1 },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return ref;
+};
+
+export { useImpressionTracking };

--- a/client-toss/src/shared/lib/analytics.ts
+++ b/client-toss/src/shared/lib/analytics.ts
@@ -8,7 +8,10 @@ const trackAnalyticsError = () => {
   }
 };
 
-export const trackClick = (logName: string, params?: Record<string, unknown>) => {
+export const trackClick = (
+  logName: string,
+  params?: Record<string, unknown>,
+) => {
   try {
     Analytics.click({ ...params, log_name: logName });
   } catch {

--- a/client-toss/src/shared/lib/analytics.ts
+++ b/client-toss/src/shared/lib/analytics.ts
@@ -1,14 +1,39 @@
 import { Analytics } from "@apps-in-toss/web-framework";
 
-export const trackClick = (logName: string, params?: Record<string, unknown>) =>
-  Analytics.click({ log_name: logName, ...params });
+const trackAnalyticsError = () => {
+  try {
+    Analytics.click({ log_name: "analytics_error" });
+  } catch {
+    // SDK 자체가 완전히 망가진 경우 — 조용히 무시
+  }
+};
+
+export const trackClick = (logName: string, params?: Record<string, unknown>) => {
+  try {
+    Analytics.click({ ...params, log_name: logName });
+  } catch {
+    trackAnalyticsError();
+  }
+};
 
 export const trackImpression = (
   logName: string,
   params?: Record<string, unknown>,
-) => Analytics.impression({ log_name: logName, ...params });
+) => {
+  try {
+    Analytics.impression({ ...params, log_name: logName });
+  } catch {
+    trackAnalyticsError();
+  }
+};
 
 export const trackScreen = (
   logName: string,
   params?: Record<string, unknown>,
-) => Analytics.screen({ log_name: logName, ...params });
+) => {
+  try {
+    Analytics.screen({ ...params, log_name: logName });
+  } catch {
+    trackAnalyticsError();
+  }
+};

--- a/client-toss/src/shared/lib/analytics.ts
+++ b/client-toss/src/shared/lib/analytics.ts
@@ -1,9 +1,7 @@
 import { Analytics } from "@apps-in-toss/web-framework";
 
-export const trackClick = (
-  logName: string,
-  params?: Record<string, unknown>,
-) => Analytics.click({ log_name: logName, ...params });
+export const trackClick = (logName: string, params?: Record<string, unknown>) =>
+  Analytics.click({ log_name: logName, ...params });
 
 export const trackImpression = (
   logName: string,

--- a/client-toss/src/shared/lib/analytics.ts
+++ b/client-toss/src/shared/lib/analytics.ts
@@ -1,0 +1,16 @@
+import { Analytics } from "@apps-in-toss/web-framework";
+
+export const trackClick = (
+  logName: string,
+  params?: Record<string, unknown>,
+) => Analytics.click({ log_name: logName, ...params });
+
+export const trackImpression = (
+  logName: string,
+  params?: Record<string, unknown>,
+) => Analytics.impression({ log_name: logName, ...params });
+
+export const trackScreen = (
+  logName: string,
+  params?: Record<string, unknown>,
+) => Analytics.screen({ log_name: logName, ...params });

--- a/client-toss/src/shared/lib/index.ts
+++ b/client-toss/src/shared/lib/index.ts
@@ -1,1 +1,2 @@
 export { initTossAdsOnce } from "./tossAds";
+export { trackClick, trackImpression, trackScreen } from "./analytics";

--- a/client-toss/src/shared/ui/bannerAd/BannerAd.tsx
+++ b/client-toss/src/shared/ui/bannerAd/BannerAd.tsx
@@ -1,7 +1,7 @@
 import { TossAds } from "@apps-in-toss/web-framework";
 import clsx from "clsx";
 import { useEffect, useRef, useState } from "react";
-import { initTossAdsOnce } from "@/shared/lib";
+import { initTossAdsOnce, trackImpression } from "@/shared/lib";
 
 type BannerType = "list" | "feed";
 
@@ -41,6 +41,23 @@ const BannerAd = ({ adGroupId, type = "list", className }: BannerAdProps) => {
   const bannerRef = useRef<HTMLDivElement>(null);
   const [isFailed, setIsFailed] = useState(false);
   const height = BANNER_HEIGHTS[type];
+
+  useEffect(() => {
+    const el = bannerRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          trackImpression("banner_ad_impression", { ad_group_id: adGroupId });
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [adGroupId]);
 
   useEffect(() => {
     let attached: ReturnType<typeof TossAds.attachBanner> | undefined;

--- a/client-toss/src/shared/ui/bannerAd/BannerAd.tsx
+++ b/client-toss/src/shared/ui/bannerAd/BannerAd.tsx
@@ -46,10 +46,11 @@ const BannerAd = ({ adGroupId, type = "list", className }: BannerAdProps) => {
     const el = bannerRef.current;
     if (!el) return;
 
+    const adId = adGroupId;
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
-          trackImpression("banner_ad_impression", { ad_group_id: adGroupId });
+          trackImpression("banner_ad_impression", { ad_group_id: adId });
           observer.disconnect();
         }
       },
@@ -57,7 +58,7 @@ const BannerAd = ({ adGroupId, type = "list", className }: BannerAdProps) => {
     );
     observer.observe(el);
     return () => observer.disconnect();
-  }, [adGroupId]);
+  }, []);
 
   useEffect(() => {
     let attached: ReturnType<typeof TossAds.attachBanner> | undefined;

--- a/client-toss/src/views/dashboard/ui/DashboardView.tsx
+++ b/client-toss/src/views/dashboard/ui/DashboardView.tsx
@@ -3,6 +3,7 @@ import { Button, TextButton, Top } from "@toss/tds-mobile";
 import { colors } from "@toss/tds-colors";
 import { MyScoreCard } from "@/entities/myScoreCard";
 import { BannerAd } from "@/shared/ui/bannerAd";
+import { trackClick } from "@/shared/lib";
 import { Link } from "react-router-dom";
 import { Podium } from "@/entities/podium";
 
@@ -32,7 +33,10 @@ const DashboardView = () => {
         <div className="flex w-full flex-col items-center gap-4 px-(--page-px)">
           {/* 랭킹 TOP3 */}
           <Podium />
-          <Link to="/ranking">
+          <Link
+            to="/ranking"
+            onClick={() => trackClick("dashboard_to_ranking_click")}
+          >
             <TextButton size="small" variant="arrow">
               TOP 100 랭킹 보러가기
             </TextButton>

--- a/client-toss/src/views/login/ui/LoginView.tsx
+++ b/client-toss/src/views/login/ui/LoginView.tsx
@@ -1,5 +1,6 @@
 import { logoImg } from "@/shared/assets/images";
 import { BottomCTAButton } from "@/shared/ui/bottomCTAButton";
+import { trackClick } from "@/shared/lib";
 import { Paragraph, Top } from "@toss/tds-mobile";
 import { useLoginFlow } from "@/feature/login";
 import { STEPS } from "../config/steps";
@@ -64,7 +65,10 @@ const LoginView = () => {
       </div>
 
       <BottomCTAButton
-        onClick={() => handleLogin()}
+        onClick={() => {
+          trackClick("login_button_click");
+          handleLogin();
+        }}
         loading={isLoading}
         disabled={isLoading}
         background="default"

--- a/client-toss/src/views/ranking/ui/RankingView.tsx
+++ b/client-toss/src/views/ranking/ui/RankingView.tsx
@@ -1,5 +1,6 @@
 import { MyRankingSection, RankingList } from "@/entities/ranking";
 import { BannerAd } from "@/shared/ui/bannerAd";
+import { trackClick } from "@/shared/lib";
 import { Border, Button, Top } from "@toss/tds-mobile";
 import { Link } from "react-router-dom";
 
@@ -26,7 +27,10 @@ const RankingView = () => {
       </main>
 
       <footer className="sticky bottom-2 w-[90%] rounded-2xl bg-white">
-        <Link to="/dashboard">
+        <Link
+          to="/dashboard"
+          onClick={() => trackClick("ranking_back_to_dashboard_click")}
+        >
           <Button
             size="xlarge"
             variant="weak"

--- a/client-toss/src/views/submitted/ui/SubmittedView.tsx
+++ b/client-toss/src/views/submitted/ui/SubmittedView.tsx
@@ -4,6 +4,7 @@ import {
 } from "@apps-in-toss/web-framework";
 import { painterMan1Img } from "@/shared/assets/images";
 import { BannerAd } from "@/shared/ui/bannerAd";
+import { trackClick } from "@/shared/lib";
 import { BottomCTA } from "@toss/tds-mobile";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -42,6 +43,8 @@ const SubmittedView = () => {
   }, [isAdSupported]);
 
   const handleNavigateHome = () => {
+    trackClick("submitted_to_dashboard_click");
+
     if (!isAdSupported || !isAdLoaded) {
       navigate("/");
       return;
@@ -80,7 +83,6 @@ const SubmittedView = () => {
         <BannerAd adGroupId="ait-ad-test-native-image-id" type="feed" />
       </div>
 
-      {/* @ts-expect-error TDS BottomCTA.Single children 타입이 framer-motion/React 19 호환 문제로 에러 발생 */}
       <div onClick={handleNavigateHome}>
         <BottomCTA.Single>결과 확인하러 가기</BottomCTA.Single>
       </div>


### PR DESCRIPTION
## 개요

앱인토스 개발 콘솔에서 확인 가능하도록 제공된 모니터링 도구 세팅


## 관련 이슈

> ex) Closes #12, Fixes #33

- #318 

## 변경 사항

### 체크리스트

<!-- 리뷰 전에 본인이 확인해야 하는 항목 -->

- [ ] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [ ] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [ ] 주석/변수명 등 가독성을 고려했습니다.
- [ ] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [ ] API, DB 변경 시 문서화했습니다.
- [ ] 새로운 의존성 추가 시 팀과 공유했습니다.

## AI 활용 점검

> AI를 어떻게 활용했는지 적어주세요.

설계 
- plan 모드를 이용한 web-view 전용 라이브러리 학습 및 필요 함수 설계
- 모니터링 설정 이벤트 목록 설계

구현
- plan.md 기반 구현
- 체크리스트 구현 및 검증

## 추가 참고 사항

> 리뷰어가 알아야 할 특이사항, 주의사항 등을 적어주세요.

# Analytics 이벤트 로깅

앱인토스 공식 Analytics SDK를 활용해 사용자 행동을 기록해요.  
수집된 데이터는 앱인토스 콘솔 **분석 > 이벤트**에서 확인할 수 있어요.

> **주의**: 샌드박스 환경에서는 데이터가 수집되지 않아요. 실제 출시 이후 다음 날부터 콘솔에서 확인 가능해요.

---

## 공통 헬퍼 (`src/shared/lib/analytics.ts`)

`@apps-in-toss/web-framework`의 `Analytics` API를 감싼 함수 3개예요.

```typescript
import { trackClick, trackImpression, trackScreen } from "@/shared/lib";

trackClick("button_name", { extra_param: "value" });      // 버튼 클릭
trackImpression("element_name", { extra_param: "value" }); // 요소 노출
trackScreen("screen_name", { extra_param: "value" });      // 화면 진입 (커스텀 파라미터 있을 때)
```

모든 이벤트는 `log_name`으로 콘솔에서 구분돼요. 추가 파라미터는 이벤트 상세 화면에서 확인할 수 있어요.

---

## 노출 추적 훅 (`src/shared/hooks/useImpressionTracking.ts`)

요소가 화면에 **10% 이상 노출될 때 1회만** impression 이벤트를 전송하는 훅이에요.

```typescript
import { useImpressionTracking } from "@/shared/hooks/useImpressionTracking";

const MyComponent = () => {
  const ref = useImpressionTracking("element_name", { extra_param: "value" });
  return <div ref={ref}>...</div>;
};
```

`IntersectionObserver`를 사용하고, 노출 후 즉시 disconnect해서 중복 전송을 막아요.

---

## 추가된 이벤트 목록

| 이벤트 이름 | 종류 | 발생 시점 | 파일 |
|---|---|---|---|
| `login_button_click` | click | 로그인 화면 → "다음" 버튼 클릭 | `views/login` |
| `submitted_to_dashboard_click` | click | 제출 완료 화면 → "결과 확인하러 가기" 클릭 | `views/submitted` |
| `dashboard_to_ranking_click` | click | 대시보드 → "TOP 100 랭킹 보러가기" 클릭 | `views/dashboard` |
| `ranking_back_to_dashboard_click` | click | 랭킹 화면 → "결과 화면으로 돌아가기" 클릭 | `views/ranking` |
| `banner_ad_impression` | impression | 배너 광고가 화면에 10% 이상 노출될 때 (1회) | `shared/ui/bannerAd` |

> 페이지 이동 로그는 SDK에서 자동 기록되므로 별도 추가 없어요.

🚨🚨🚨🚨또 추적이 필요하다고 생각이 드는 이벤트가 있으면 말씀해주세요!

---

## 새 이벤트 추가하는 방법

🚨🚨🚨🚨 필요한 곳에 쓰세요!

### 클릭 이벤트

```typescript
import { trackClick } from "@/shared/lib";

<Button onClick={() => {
  trackClick("button_name");
  // 기존 동작
}}>
  버튼
</Button>
```

### 노출 이벤트

```typescript
import { useImpressionTracking } from "@/shared/hooks/useImpressionTracking";

const ref = useImpressionTracking("element_name");
return <div ref={ref}>노출 감지할 요소</div>;
```

### 이벤트 이름 컨벤션

`{화면}_{동작}` 형태로 작성해요.

- `login_button_click` ✓
- `btn_click` ✗ (어느 화면인지 불명확)
- `ranking_replay_click` ✓

## 스크린샷 / UI 변경 (선택)

> UI가 변경된 경우 스크린샷을 첨부해주세요.

<img width="1470" height="587" alt="image" src="https://github.com/user-attachments/assets/0ee78480-bc37-4381-a217-93e2e53ca76a" />

여기에 기록될 예정

<img width="536" height="330" alt="image" src="https://github.com/user-attachments/assets/4940097b-d725-4b23-ab41-b782672c06b0" />

전환지표 같은 경우에는 코드로 트래킹하는 것이 아니라 앱인토스 자체에서 전달해주는 지표.
3개까지 가능하여 **재방문 유저 수, 광고 시청 유저 수, 5분 이상 체류 유저 수** 3가지로 설정해뒀는데, 추후 코드로 트래킹할 수 있는 부분이 있다면 제외하고 다른 지표로 교체하면 될 것 같아요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 광고 노출 및 클릭, 화면 이동에 대한 분석 이벤트(trackClick/trackImpression/trackScreen) 추가
  * DOM 가시성을 감지해 최초 노출을 기록하는 공용 훅 추가
  * 배너 광고, 로그인 버튼, 랭킹·대시보드 네비게이션, 드로잉 툴바 등 주요 UI에 추적 호출 적용

* **Refactor**
  * 로그인 흐름 내부 로직 정리 및 재시도/대기 플래그 처리 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->