### PR TITLE
[fix] mikro-orm.config.ts 에서 import dotenv/config 삭제

### DIFF
--- a/server-toss/src/mikro-orm.config.ts
+++ b/server-toss/src/mikro-orm.config.ts
@@ -1,7 +1,6 @@
 import { Migrator } from "@mikro-orm/migrations";
 import { defineConfig } from "@mikro-orm/mysql";
 import { SeedManager } from "@mikro-orm/seeder";
-import "dotenv/config";
 import { AdView } from "./modules/ad/ad-view.entity";
 import { Drawing } from "./modules/drawing/drawing.entity";
 import { PointLog } from "./modules/point/point-log.entity";


### PR DESCRIPTION
## 개요

mikro-orm.config.ts 에서 import dotenv/config 삭제했습니다.
## 관련 이슈

## 변경 사항

- dotenv는 @nestjs/config에 내부적으로 사용 중인 의존성이며, 프로젝트 내에 명시적으로 의존하는 상태가 아님.
- 그래서 `pnpm deploy` 후에 `dotenv`패키지에 대한 링크가 생성되지 않음.
- 이로 인해서 mikro-orm.config.ts에서 직접 import 할 때 모듈을 찾지 못하여 에러가 발생
- 이를 해결하기 위해 import dotenv/config를 삭제함.
- nestjs/config 모듈 로딩 시에 import dotenv/config를 실행하기 때문에 동작에는 문제 없음을 확인했습니다.

### 체크리스트

<!-- 리뷰 전에 본인이 확인해야 하는 항목 -->

- [ ] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [ ] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [ ] 주석/변수명 등 가독성을 고려했습니다.
- [ ] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [ ] API, DB 변경 시 문서화했습니다.
- [ ] 새로운 의존성 추가 시 팀과 공유했습니다.

## 테스트 및 검증 내용

> 어떻게 테스트했고, 어떤 결과를 확인했는지 적어주세요.

## AI 활용 점검

> AI를 어떻게 활용했는지 적어주세요.

## 추가 참고 사항

> 리뷰어가 알아야 할 특이사항, 주의사항 등을 적어주세요.

## 스크린샷 / UI 변경 (선택)

> UI가 변경된 경우 스크린샷을 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **내부 개선사항**
  * 서버 초기화 프로세스를 리팩토링했습니다. 애플리케이션의 기능과 설정은 변경되지 않았으며, 내부 구성 로드 메커니즘만 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->