### PR TITLE
[fix] certs 파일 권한 설정 수정

### DIFF
--- a/.github/workflows/deploy-toss-backend.yml
+++ b/.github/workflows/deploy-toss-backend.yml
@@ -35,12 +35,21 @@ jobs:
 
       - name: Copy secret file
         run: |
+          set -e 
+
           mkdir -p ~/deploy/certs
           printf '%s' "$PRIVATE_KEY" | base64 --decode > ~/deploy/certs/davinci_private.key 
           printf '%s' "$PUBLIC_CERT" | base64 --decode > ~/deploy/certs/davinci_public.cert
 
-          chmod 600 ~/deploy/certs/davinci_private.key 
-          chmod 644 ~/deploy/certs/davinci_public.cert
+          chown 1001:1001 ~/deploy/certs/davinci_private.key
+          chown 1001:1001 ~/deploy/certs/davinci_public.cert
+
+          chmod 400 ~/deploy/certs/davinci_private.key 
+          chmod 400 ~/deploy/certs/davinci_public.cert
+
+          test -s ~/deploy/certs/davinci_private.key
+          test -s ~/deploy/certs/davinci_public.cert
+
         env:
           PRIVATE_KEY: ${{ secrets.DAVINCI_PRIVATE_KEY }}
           PUBLIC_CERT: ${{ secrets.DAVINCI_PUBLIC_CERT }}
@@ -78,7 +87,7 @@ jobs:
         if: always()
         working-directory: ./deploy-toss
         run: |
-          docker compose -f compose.yml logs --tail=50
+          IMAGE_TAG=davinci-toss docker compose -f compose.yml logs --tail=50 app
 
       - name: Clean
         if: always()

--- a/deploy-toss/compose.yml
+++ b/deploy-toss/compose.yml
@@ -8,9 +8,11 @@ services:
       - "3000:3000"
     env_file: .env
     restart: unless-stopped
-    volumes:
-      - ~/deploy/certs/davinci_private.key:/run/certs/davinci_private.key:ro
-      - ~/deploy/certs/davinci_public.cert:/run/certs/davinci_public.cert:ro
+    secrets:
+      - source: toss_private_key
+        target: /run/certs/davinci_private.key
+      - source: toss_public_cert
+        target: /run/certs/davinci_public.cert
     environment:
       - TOSS_CLIENT_KEY_PATH=/run/certs/davinci_private.key
       - TOSS_CLIENT_CERT_PATH=/run/certs/davinci_public.cert
@@ -44,3 +46,9 @@ services:
         "--config",
         "mikro-orm.migration.config.cjs",
       ]
+
+secrets:
+  toss_private_key:
+    file: /home/ubuntu/deploy/certs/davinci_private.key
+  toss_public_cert:
+    file: /home/ubuntu/deploy/certs/davinci_public.cert


### PR DESCRIPTION


## 개요

certs 파일 권한 설정 이슈 수정
## 관련 이슈


## 변경 사항

- Actions 스크립트에서 certs 파일 복사 진행 후, Docker 컨테이너에서 certs 파일을 읽어서 사용하는 구조
- 하지만 Actions 스크립트는 ubuntu 사용자이고, Docker 컨테이너의 실행 사용자는 nestjs로 사용자가 달라서 permission denied에러가 발생하고 있었음.
- 그래서 Actions 스크립트에서 certs 파일을 복사할 때, chown 1001를 실행하도록 수정함.
- 추가로 compose.yml에서 민감 정보를 볼륨 마운트가 아닌 secerts 설정 방식으로 수정

### 체크리스트

<!-- 리뷰 전에 본인이 확인해야 하는 항목 -->

- [ ] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [ ] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [ ] 주석/변수명 등 가독성을 고려했습니다.
- [ ] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [ ] API, DB 변경 시 문서화했습니다.
- [ ] 새로운 의존성 추가 시 팀과 공유했습니다.

## 테스트 및 검증 내용

> 어떻게 테스트했고, 어떤 결과를 확인했는지 적어주세요.

## AI 활용 점검

> AI를 어떻게 활용했는지 적어주세요.

## 추가 참고 사항

> 리뷰어가 알아야 할 특이사항, 주의사항 등을 적어주세요.

## 스크린샷 / UI 변경 (선택)

> UI가 변경된 경우 스크린샷을 첨부해주세요.