### PR TITLE
[fix]  테스트용 광고 그룹 ID를 실 발급 ID로 교체

### DIFF
--- a/client-toss/src/feature/playChance/hooks/useRewardAd.ts
+++ b/client-toss/src/feature/playChance/hooks/useRewardAd.ts
@@ -3,8 +3,8 @@ import {
   showFullScreenAd,
 } from "@apps-in-toss/web-framework";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { AD_GROUP_IDS } from "@/shared/config";
 
-const AD_GROUP_ID = "ait-ad-test-rewarded-id";
 const AD_TIMEOUT_MS = 10_000;
 
 export const useRewardAd = () => {
@@ -17,7 +17,7 @@ export const useRewardAd = () => {
     adUnregisterRef.current?.();
     if (!isSupported) return;
     adUnregisterRef.current = loadFullScreenAd({
-      options: { adGroupId: AD_GROUP_ID },
+      options: { adGroupId: AD_GROUP_IDS.REWARDED },
       onEvent: (event) => {
         if (event.type === "loaded") setIsAdLoaded(true);
       },
@@ -58,7 +58,7 @@ export const useRewardAd = () => {
         }, AD_TIMEOUT_MS);
 
         showFullScreenAd({
-          options: { adGroupId: AD_GROUP_ID },
+          options: { adGroupId: AD_GROUP_IDS.REWARDED },
           onEvent: (event) => {
             if (event.type === "userEarnedReward") rewarded = true;
             if (event.type === "dismissed") {

--- a/client-toss/src/shared/config/adGroupIds.ts
+++ b/client-toss/src/shared/config/adGroupIds.ts
@@ -1,0 +1,5 @@
+export const AD_GROUP_IDS = {
+  BANNER_LIST: "ait.v2.live.9e1e89cbc38445f0",
+  BANNER_FEED: "ait.v2.live.89b47420ce2c497d",
+  REWARDED: "ait.v2.live.932e847f2b0c499c",
+} as const;

--- a/client-toss/src/shared/config/index.ts
+++ b/client-toss/src/shared/config/index.ts
@@ -1,0 +1,1 @@
+export { AD_GROUP_IDS } from "./adGroupIds";

--- a/client-toss/src/views/dashboard/ui/DashboardView.tsx
+++ b/client-toss/src/views/dashboard/ui/DashboardView.tsx
@@ -6,6 +6,7 @@ import {
   serverTossApi,
   setCachedNickname,
 } from "@/shared/api";
+import { AD_GROUP_IDS } from "@/shared/config";
 import { formatLocalDate, trackClick, useExitGuard } from "@/shared/lib";
 import { BannerAd } from "@/shared/ui/bannerAd";
 import { getDeviceId } from "@apps-in-toss/web-framework";
@@ -317,7 +318,7 @@ const DashboardView = () => {
         )}
       </div>
 
-      <BannerAd adGroupId="ait-ad-test-banner-id" className="mt-3 mb-3" />
+      <BannerAd adGroupId={AD_GROUP_IDS.BANNER_LIST} className="mt-3 mb-3" />
 
       {/* 하단 버튼 */}
       <div className="flex flex-col gap-3 px-(--page-px)">

--- a/client-toss/src/views/memorize/ui/MemorizeView.tsx
+++ b/client-toss/src/views/memorize/ui/MemorizeView.tsx
@@ -1,6 +1,7 @@
 import { PhaseHeader } from "@/entities/phaseHeader";
 import { drawPromptOnCanvas, useCanvasSetup } from "@/feature/drawing";
 import { useRequirePlaySession } from "@/feature/playChance";
+import { AD_GROUP_IDS } from "@/shared/config";
 import {
   MEMORIZE_SECONDS,
   useCountdown,
@@ -91,7 +92,7 @@ const MemorizeView = () => {
           </div>
         </div>
 
-        <BannerAd type="feed" adGroupId="ait-ad-test-native-image-id" />
+        <BannerAd type="feed" adGroupId={AD_GROUP_IDS.BANNER_FEED} />
       </div>
 
       <ConfirmDialog

--- a/client-toss/src/views/ranking/ui/RankingView.tsx
+++ b/client-toss/src/views/ranking/ui/RankingView.tsx
@@ -1,4 +1,5 @@
 import { MyRankingSection, RankingList } from "@/entities/ranking";
+import { AD_GROUP_IDS } from "@/shared/config";
 import { BannerAd } from "@/shared/ui/bannerAd";
 import { Border, Top } from "@toss/tds-mobile";
 
@@ -23,7 +24,7 @@ const RankingView = () => {
         />
         <Border />
         <MyRankingSection />
-        <BannerAd adGroupId="ait-ad-test-banner-id" className="mb-6" />
+        <BannerAd adGroupId={AD_GROUP_IDS.BANNER_LIST} className="mb-6" />
         <RankingList />
       </main>
     </div>

--- a/client-toss/src/views/rankingDetail/ui/RankingDetailView.tsx
+++ b/client-toss/src/views/rankingDetail/ui/RankingDetailView.tsx
@@ -1,4 +1,5 @@
 import { MyScoreCard, useDrawing } from "@/entities/myScoreCard";
+import { AD_GROUP_IDS } from "@/shared/config";
 import { BannerAd } from "@/shared/ui/bannerAd";
 import { colors } from "@toss/tds-colors";
 import { Button, Skeleton, Top } from "@toss/tds-mobile";
@@ -41,7 +42,7 @@ const RankingDetailView = () => {
         </div>
       )}
 
-      <BannerAd adGroupId="ait-ad-test-banner-id" className="mt-3 mb-3" />
+      <BannerAd adGroupId={AD_GROUP_IDS.BANNER_LIST} className="mt-3 mb-3" />
 
       <div className="mt-8 px-(--page-px)">
         <Link to="/ranking">

--- a/client-toss/src/views/submitted/ui/SubmittedView.tsx
+++ b/client-toss/src/views/submitted/ui/SubmittedView.tsx
@@ -1,6 +1,7 @@
 import { drawStrokesOnCanvas, useCanvasSetup } from "@/feature/drawing";
 import { usePlayChance } from "@/feature/playChance";
 import { serverTossApi } from "@/shared/api";
+import { AD_GROUP_IDS } from "@/shared/config";
 import { trackClick, useExitGuard, useRequiredState } from "@/shared/lib";
 import { BannerAd } from "@/shared/ui/bannerAd";
 import { Score } from "@/shared/ui/score";
@@ -127,7 +128,7 @@ const SubmittedView = () => {
         </div>
 
         <div className="pb-3">
-          <BannerAd adGroupId="ait-ad-test-native-image-id" type="list" />
+          <BannerAd adGroupId={AD_GROUP_IDS.BANNER_LIST} type="list" />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- 앱인토스 검수에서 출시 번들에 `ait-ad-test-*` ID가 포함됐다는 사유로 반려된 건 대응
- 콘솔에서 발급받은 라이브 ID 3종(배너 리스트형/피드형/리워드)으로 전부 교체
- `client-toss/src/shared/config/adGroupIds.ts` 에 상수로 모아 관리, 5개 view + `useRewardAd` 훅에서 import

## 변경 내역

| 위치 | 기존 | 변경 후 |
|---|---|---|
| Dashboard / Ranking / RankingDetail | `ait-ad-test-banner-id` | `AD_GROUP_IDS.BANNER_LIST` |
| Submitted (`type="list"`) | `ait-ad-test-native-image-id` ⚠️ | `AD_GROUP_IDS.BANNER_LIST` (정정) |
| Memorize (`type="feed"`) | `ait-ad-test-native-image-id` | `AD_GROUP_IDS.BANNER_FEED` |
| useRewardAd | `ait-ad-test-rewarded-id` | `AD_GROUP_IDS.REWARDED` |

> SubmittedView는 `type="list"`(96px 사이즈)인데 피드형 테스트 ID를 쓰던 미스매치 상태였어요. 리스트형 라이브 ID로 정정했습니다.

## 검증

- [x] `pnpm --filter client-toss lint` (0 errors)
- [x] `pnpm --filter client-toss test` (16 files / 97 tests pass)
- [x] `pnpm --filter client-toss qa:ci` (Ad Integration / Bundle Size 포함 8/8 PASS)
- [x] `git grep ait-ad-test` 잔여물 0건
- [ ] 토스 시뮬레이터/실기기에서 5개 view + 다시그리기 리워드 광고 실제 로드 확인 (수동)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **리팩토링**
  * 광고 설정 관리 구조를 개선하여 코드 유지보수성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->