### PR TITLE
[fix] 리워드 광고 시청 후 게임 미진입 + 다시하기에 광고 적용

### DIFF
--- a/client-toss/src/feature/playChance/hooks/useRewardAd.ts
+++ b/client-toss/src/feature/playChance/hooks/useRewardAd.ts
@@ -5,8 +5,6 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { AD_GROUP_IDS } from "@/shared/config";
 
-const AD_TIMEOUT_MS = 10_000;
-
 export const useRewardAd = () => {
   const isSupported = loadFullScreenAd.isSupported();
   // 광고 SDK 미지원(로컬 dev 등)에서는 곧바로 "로드 완료" 상태로 간주해 흐름 차단을 막는다.
@@ -50,21 +48,20 @@ export const useRewardAd = () => {
         let rewarded = false;
         let done = false;
 
-        const timer = setTimeout(() => {
-          if (done) return;
-          done = true;
-          reloadAd();
-          reject(new Error("timeout"));
-        }, AD_TIMEOUT_MS);
-
         showFullScreenAd({
           options: { adGroupId: AD_GROUP_IDS.REWARDED },
           onEvent: (event) => {
+            if (event.type === "failedToShow") {
+              if (done) return;
+              done = true;
+              reloadAd();
+              reject(new Error("failedToShow"));
+              return;
+            }
             if (event.type === "userEarnedReward") rewarded = true;
             if (event.type === "dismissed") {
               if (done) return;
               done = true;
-              clearTimeout(timer);
               reloadAd();
               if (rewarded) resolve();
               else reject(new Error("closed"));
@@ -73,7 +70,6 @@ export const useRewardAd = () => {
           onError: (err) => {
             if (done) return;
             done = true;
-            clearTimeout(timer);
             reloadAd();
             reject(err);
           },

--- a/client-toss/src/views/ranking/ui/RankingView.tsx
+++ b/client-toss/src/views/ranking/ui/RankingView.tsx
@@ -9,7 +9,7 @@ const RankingView = () => {
       data-no-safe-area-bottom
       className="flex min-h-full flex-col items-center pb-[env(safe-area-inset-bottom)]"
     >
-      <main className="w-full">
+      <main className="w-full pb-8">
         <Top
           title={
             <Top.TitleParagraph role="heading" aria-level={1}>

--- a/client-toss/src/views/submitted/ui/SubmittedView.test.tsx
+++ b/client-toss/src/views/submitted/ui/SubmittedView.test.tsx
@@ -46,6 +46,11 @@ vi.mock("@/shared/ui/bannerAd", () => ({
 
 const mockCharge = vi.fn().mockResolvedValue(undefined);
 const mockStartPlay = vi.fn().mockResolvedValue(true);
+const mockShowAd = vi.fn().mockResolvedValue(undefined);
+const mockUseRewardAd = vi.fn(() => ({
+  isAdLoaded: false as boolean,
+  showAd: mockShowAd,
+}));
 vi.mock("@/feature/playChance", () => ({
   usePlayChance: () => ({
     hasChance: true,
@@ -53,6 +58,7 @@ vi.mock("@/feature/playChance", () => ({
     charge: mockCharge,
     startPlay: mockStartPlay,
   }),
+  useRewardAd: () => mockUseRewardAd(),
 }));
 
 const mockRouteState = {
@@ -85,6 +91,10 @@ describe("SubmittedView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    mockUseRewardAd.mockImplementation(() => ({
+      isAdLoaded: false,
+      showAd: mockShowAd,
+    }));
   });
 
   it("점수와 완성 텍스트가 렌더링된다", () => {
@@ -240,5 +250,52 @@ describe("SubmittedView", () => {
     await waitFor(() => {
       expect(screen.getByText("다시 시도해주세요.")).toBeInTheDocument();
     });
+  });
+
+  it("광고가 로드된 경우 다시하기 시 광고 시청 후 recordAdView를 호출한다", async () => {
+    vi.useRealTimers();
+    mockUseRewardAd.mockImplementation(() => ({
+      isAdLoaded: true,
+      showAd: mockShowAd,
+    }));
+    const user = userEvent.setup();
+    vi.mocked(serverTossApi.getPrompt).mockResolvedValue({
+      promptId: 7,
+      strokes: [],
+    });
+
+    renderWithState();
+
+    await user.click(screen.getByText("다시하기"));
+
+    await waitFor(() => {
+      expect(mockShowAd).toHaveBeenCalled();
+    });
+    expect(serverTossApi.recordAdView).toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/memorize",
+      expect.objectContaining({
+        state: expect.objectContaining({ promptId: 7 }),
+      }),
+    );
+  });
+
+  it("광고가 로드되지 않은 경우 다시하기 시 광고/recordAdView 호출 없이 진행한다", async () => {
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    vi.mocked(serverTossApi.getPrompt).mockResolvedValue({
+      promptId: 8,
+      strokes: [],
+    });
+
+    renderWithState();
+
+    await user.click(screen.getByText("다시하기"));
+
+    await waitFor(() => {
+      expect(mockCharge).toHaveBeenCalled();
+    });
+    expect(mockShowAd).not.toHaveBeenCalled();
+    expect(serverTossApi.recordAdView).not.toHaveBeenCalled();
   });
 });

--- a/client-toss/src/views/submitted/ui/SubmittedView.tsx
+++ b/client-toss/src/views/submitted/ui/SubmittedView.tsx
@@ -1,5 +1,5 @@
 import { drawStrokesOnCanvas, useCanvasSetup } from "@/feature/drawing";
-import { usePlayChance } from "@/feature/playChance";
+import { usePlayChance, useRewardAd } from "@/feature/playChance";
 import { serverTossApi } from "@/shared/api";
 import { AD_GROUP_IDS } from "@/shared/config";
 import { trackClick, useExitGuard, useRequiredState } from "@/shared/lib";
@@ -23,6 +23,7 @@ const SubmittedView = () => {
   const { showDialog, setShowDialog } = useExitGuard();
   const { containerRef, canvasRef, ctxRef, canvasSize } = useCanvasSetup();
   const { charge, startPlay } = usePlayChance();
+  const { isAdLoaded, showAd } = useRewardAd();
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isReplaying, setIsReplaying] = useState(false);
@@ -63,10 +64,13 @@ const SubmittedView = () => {
     if (isReplaying) return;
     setIsReplaying(true);
     try {
-      try {
-        await serverTossApi.recordAdView();
-      } catch (err) {
-        console.error("[recordAdView 실패, 무시]", err);
+      if (isAdLoaded) {
+        await showAd();
+        try {
+          await serverTossApi.recordAdView();
+        } catch (err) {
+          console.error("[recordAdView 실패, 무시]", err);
+        }
       }
       await charge();
       const started = await startPlay();


### PR DESCRIPTION
## 개요

운영 환경(토스 앱)에서 대시보드 "다시 도전하기"로 리워드 광고를 끝까지 시청해도 게임에 진입하지 못하는 버그를 수정했어요. 같은 광고 흐름을 일관되게 적용하기 위해 결과 화면("그림을 완성했어요")의 "다시하기" 버튼에도 동일한 리워드 광고를 걸어 뒀어요.

## 관련 이슈

- Closes #346

## 변경 사항

### 1. `useRewardAd` — 광고 시청 중 timeout 제거 (운영 버그 fix)

토스 SDK 리워드 광고는 `requested → show → impression → [15~30초 시청] → userEarnedReward → dismissed` 순서로 이벤트가 와요. 그런데 `showAd()` 안에 걸어 둔 10초 `setTimeout`이 시청 도중에 발동해서 Promise를 `reject(new Error("timeout"))`로 종료시키고 있었어요. `handleRetry`/`handleReplay`의 catch로 빠져 "일시적 오류" 토스트만 뜨고, 이후에 SDK가 보내는 `dismissed`/`userEarnedReward` 이벤트는 `done=true` 플래그 때문에 무시돼서 게임에 진입하지 못했어요.

이 timeout은 원래 SDK가 어떤 이벤트도 보내지 않는 hang 상황 방어용이었는데, 실제로는 `failedToShow`/`onError`/`dismissed` 중 하나는 SDK가 반드시 보내 주기 때문에 클라이언트 쪽에서 별도 시간 측정이 필요하지 않아요.

- `AD_TIMEOUT_MS`, `setTimeout`, `clearTimeout` 모두 제거
- `failedToShow` 이벤트를 명시적으로 처리해 광고 표시 실패 시 즉시 reject
- `dismissed`/`userEarnedReward`/`onError`만으로 흐름 결정

### 2. `SubmittedView` "다시하기" — 리워드 광고 적용 (feat)

결과 화면의 "다시하기" 버튼은 광고 없이 `recordAdView`만 호출하고 게임에 진입하던 상태였어요. 광고를 보지도 않았는데 광고 시청 기록 API를 부르는 부정확한 동작이고, "다시 도전하기"와 정책도 불일치였어요. `useRewardAd`를 추가해서 동일한 흐름으로 통일했어요.

- `useRewardAd` 훅 사용 (`AD_GROUP_IDS.REWARDED`)
- 광고가 로드된 경우에만 `showAd()` 시청 → `recordAdView()` 호출
- SDK 미지원/광고 미로드 환경에서는 광고 분기 자체 스킵 (`DashboardView.handleRetry`와 동일 패턴)
- 광고 분기 테스트 2개 추가

### 3. `RankingView` 하단 패딩 (design)

`<main>`에 `pb-8`을 추가해 마지막 항목이 시스템 UI에 너무 붙지 않도록 여백 확보.

### 변경 파일

| 파일 | 변경 |
|---|---|
| `client-toss/src/feature/playChance/hooks/useRewardAd.ts` | timeout 로직 제거, `failedToShow` 핸들러 추가 |
| `client-toss/src/views/submitted/ui/SubmittedView.tsx` | `useRewardAd` 도입, 광고 시청 후에만 `recordAdView` 호출 |
| `client-toss/src/views/submitted/ui/SubmittedView.test.tsx` | mock 정리 + 광고 분기 테스트 2개 추가 |
| `client-toss/src/views/ranking/ui/RankingView.tsx` | `<main>`에 `pb-8` 추가 |

### 체크리스트

- [x] 코드 스타일 가이드/린트 규칙을 준수했어요.
- [x] 불필요한 콘솔/디버깅 코드를 제거했어요.
- [x] 주석/변수명 등 가독성을 고려했어요.
- [x] 영향 범위를 확인했어요. (다른 페이지/기능 깨짐 여부)
- [x] API, DB 변경 시 문서화했어요. (해당 없음)
- [x] 새로운 의존성 추가 시 팀과 공유했어요. (해당 없음)

## 테스트 및 검증 내용

자동 검증 통과:
- `pnpm --filter client-toss lint` — 0 errors
- `pnpm --filter client-toss test` — 16 files / 99 tests passed (광고 분기 테스트 2개 추가됨)
- `pnpm --filter client-toss build` (PR CI에서 검증)

**수동 확인이 필요한 부분 (토스 샌드박스 / 실기기)**

- [ ] 일일 1회 소진 후 대시보드 "다시 도전하기" 클릭 → 광고 15초+ 시청 → `/memorize`로 자동 이동
- [ ] 결과 화면 "다시하기" 클릭 → 광고 15초+ 시청 → `/memorize`로 자동 이동
- [ ] 광고 도중 닫기 → 토스트 표시되고 게임 미진입 (회귀 방지)
- [ ] RankingView TOP100 마지막 카드와 하단 시스템 UI 사이 패딩 확인

로컬 dev에서는 `loadFullScreenAd.isSupported() === false`라 `showAd()`가 즉시 resolve되어 timeout 경로 자체가 안 타기 때문에 이 버그를 재현/검증할 수 없어요. 토스 샌드박스에서만 확인 가능합니다.

## AI 활용 점검

- 토스 SDK 인앱 광고 2.0 ver2 문서로 리워드 광고 이벤트 흐름(`requested → show → impression → userEarnedReward → dismissed`)을 확인하고, 10초 timeout이 시청 시간을 잡아먹는 구조를 식별했어요.
- "광고를 두 번 봐야 진입" 증상이 1회차 reject 후 2회차에서 짧거나 캐시된 광고가 timeout 안에 dismissed까지 도달한 케이스로 설명되는지 시나리오 분석에 활용했어요.
- SubmittedView 변경 시 DashboardView의 `handleRetry` 패턴과 일관성을 맞추는 검토에 활용했어요.

## 추가 참고 사항
- timeout이 사라진 자리는 SDK의 `failedToShow`/`onError`가 채워 줘요. SDK가 hang하는 극히 드문 상황(어떤 이벤트도 안 보냄)이 발생하면 다시 도전하기 버튼이 로딩 상태로 남는 이론적 위험이 있는데, 토스 SDK 동작상 거의 발생하지 않는 케이스라 이번 PR에서는 별도 가드를 넣지 않았어요.
- `useRewardAd`가 SDK 미지원 환경(로컬 dev)에서는 `isAdLoaded=true`로 시작하는 기존 동작은 유지했어요. 정책상 별개 정리 거리(SDK 지원 여부에 따른 광고 강제 시청 일관성)는 후속 작업으로 남겨 둬요.

## 스크린샷 / UI 변경

(해당 없음 — UI 텍스트/레이아웃 시각 변경 없음. RankingView 하단 패딩 추가는 미세 변경.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 재시도 플로우에서 보상 광고 통합 추가

* **버그 수정**
  * 광고 실패 처리 로직 개선

* **스타일**
  * 랭킹 뷰에 하단 여백 추가

* **테스트**
  * 보상 광고 플로우에 대한 테스트 커버리지 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->