### PR TITLE
fix(be): play_chances 테이블 누락 마이그레이션 복구

### DIFF
--- a/server-toss/mikro-orm.migration.config.cjs
+++ b/server-toss/mikro-orm.migration.config.cjs
@@ -7,6 +7,8 @@ const { DailyPrompt } = require("./dist/modules/prompt/daily-prompt.entity");
 const { PointLog } = require("./dist/modules/point/point-log.entity");
 const { AdView } = require("./dist/modules/ad/ad-view.entity");
 const { Ranking } = require("./dist/modules/ranking/ranking.entity");
+const { PlayChance } = require("./dist/modules/chance/play-chance.entity");
+const { ShareLog } = require("./dist/modules/chance/share-log.entity");
 
 const { Migrator } = require("@mikro-orm/migrations");
 const { SeedManager } = require("@mikro-orm/seeder");
@@ -18,7 +20,17 @@ module.exports = defineConfig({
   port: parseInt(process.env.MYSQL_PORT ?? "3306"),
   user: process.env.MYSQL_USER ?? "root",
   password: process.env.MYSQL_PASSWORD ?? "",
-  entities: [User, Drawing, Prompt, DailyPrompt, PointLog, AdView, Ranking],
+  entities: [
+    User,
+    Drawing,
+    Prompt,
+    DailyPrompt,
+    PointLog,
+    AdView,
+    Ranking,
+    PlayChance,
+    ShareLog,
+  ],
   debug: process.env.NODE_ENV !== "production",
   forceUtcTimezone: true, // UTC로 시간 설정 고정
   allowGlobalContext: process.env.NODE_ENV === "test", // 테스트환경의 전역 em 사용을 위한 설정

--- a/server-toss/src/migrations/.snapshot-daVinci_toss.json
+++ b/server-toss/src/migrations/.snapshot-daVinci_toss.json
@@ -62,7 +62,9 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": ["drawing"]
+          "enumItems": [
+            "drawing"
+          ]
         },
         "user_key": {
           "name": "user_key",
@@ -82,14 +84,18 @@
       },
       "indexes": [
         {
-          "columnNames": ["user_key"],
+          "columnNames": [
+            "user_key"
+          ],
           "keyName": "ad_views_user_key_index",
           "unique": false,
           "primary": false,
           "constraint": false
         },
         {
-          "columnNames": ["id"],
+          "columnNames": [
+            "id"
+          ],
           "keyName": "PRIMARY",
           "unique": true,
           "primary": true,
@@ -99,11 +105,15 @@
       "checks": [],
       "foreignKeys": {
         "ad_views_user_key_foreign": {
-          "columnNames": ["user_key"],
+          "columnNames": [
+            "user_key"
+          ],
           "constraintName": "ad_views_user_key_foreign",
           "localTableName": "ad_views",
           "referencedTableName": "users",
-          "referencedColumnNames": ["user_key"],
+          "referencedColumnNames": [
+            "user_key"
+          ],
           "updateRule": "no action",
           "deleteRule": "no action"
         }
@@ -162,21 +172,27 @@
       },
       "indexes": [
         {
-          "columnNames": ["prompt_date"],
+          "columnNames": [
+            "prompt_date"
+          ],
           "keyName": "daily_prompts_prompt_date_unique",
           "unique": true,
           "primary": false,
           "constraint": true
         },
         {
-          "columnNames": ["prompt_id"],
+          "columnNames": [
+            "prompt_id"
+          ],
           "keyName": "daily_prompts_prompt_id_index",
           "unique": false,
           "primary": false,
           "constraint": false
         },
         {
-          "columnNames": ["id"],
+          "columnNames": [
+            "id"
+          ],
           "keyName": "PRIMARY",
           "unique": true,
           "primary": true,
@@ -186,11 +202,15 @@
       "checks": [],
       "foreignKeys": {
         "daily_prompts_prompt_id_foreign": {
-          "columnNames": ["prompt_id"],
+          "columnNames": [
+            "prompt_id"
+          ],
           "constraintName": "daily_prompts_prompt_id_foreign",
           "localTableName": "daily_prompts",
           "referencedTableName": "prompts",
-          "referencedColumnNames": ["id"],
+          "referencedColumnNames": [
+            "id"
+          ],
           "updateRule": "no action",
           "deleteRule": "no action"
         }
@@ -324,21 +344,27 @@
       },
       "indexes": [
         {
-          "columnNames": ["prompt_id"],
+          "columnNames": [
+            "prompt_id"
+          ],
           "keyName": "drawings_prompt_id_index",
           "unique": false,
           "primary": false,
           "constraint": false
         },
         {
-          "columnNames": ["user_key"],
+          "columnNames": [
+            "user_key"
+          ],
           "keyName": "drawings_user_key_index",
           "unique": false,
           "primary": false,
           "constraint": false
         },
         {
-          "columnNames": ["id"],
+          "columnNames": [
+            "id"
+          ],
           "keyName": "PRIMARY",
           "unique": true,
           "primary": true,
@@ -348,20 +374,28 @@
       "checks": [],
       "foreignKeys": {
         "drawings_prompt_id_foreign": {
-          "columnNames": ["prompt_id"],
+          "columnNames": [
+            "prompt_id"
+          ],
           "constraintName": "drawings_prompt_id_foreign",
           "localTableName": "drawings",
           "referencedTableName": "prompts",
-          "referencedColumnNames": ["id"],
+          "referencedColumnNames": [
+            "id"
+          ],
           "updateRule": "no action",
           "deleteRule": "no action"
         },
         "drawings_user_key_foreign": {
-          "columnNames": ["user_key"],
+          "columnNames": [
+            "user_key"
+          ],
           "constraintName": "drawings_user_key_foreign",
           "localTableName": "drawings",
           "referencedTableName": "users",
-          "referencedColumnNames": ["user_key"],
+          "referencedColumnNames": [
+            "user_key"
+          ],
           "updateRule": "no action",
           "deleteRule": "no action"
         }
@@ -385,8 +419,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "count": {
           "name": "count",
@@ -401,8 +434,7 @@
           "scale": 0,
           "default": "0",
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "last_reset_at": {
           "name": "last_reset_at",
@@ -417,13 +449,14 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "date"
+          "enumItems": []
         }
       },
       "indexes": [
         {
-          "columnNames": ["user_key"],
+          "columnNames": [
+            "user_key"
+          ],
           "keyName": "PRIMARY",
           "unique": true,
           "primary": true,
@@ -496,7 +529,11 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": ["ad", "share", "drawing"]
+          "enumItems": [
+            "ad",
+            "share",
+            "drawing"
+          ]
         },
         "point_amount": {
           "name": "point_amount",
@@ -531,14 +568,18 @@
       },
       "indexes": [
         {
-          "columnNames": ["user_key"],
+          "columnNames": [
+            "user_key"
+          ],
           "keyName": "point_logs_user_key_index",
           "unique": false,
           "primary": false,
           "constraint": false
         },
         {
-          "columnNames": ["id"],
+          "columnNames": [
+            "id"
+          ],
           "keyName": "PRIMARY",
           "unique": true,
           "primary": true,
@@ -548,11 +589,15 @@
       "checks": [],
       "foreignKeys": {
         "point_logs_user_key_foreign": {
-          "columnNames": ["user_key"],
+          "columnNames": [
+            "user_key"
+          ],
           "constraintName": "point_logs_user_key_foreign",
           "localTableName": "point_logs",
           "referencedTableName": "users",
-          "referencedColumnNames": ["user_key"],
+          "referencedColumnNames": [
+            "user_key"
+          ],
           "updateRule": "no action",
           "deleteRule": "no action"
         }
@@ -596,7 +641,9 @@
       },
       "indexes": [
         {
-          "columnNames": ["id"],
+          "columnNames": [
+            "id"
+          ],
           "keyName": "PRIMARY",
           "unique": true,
           "primary": true,
@@ -749,7 +796,11 @@
       },
       "indexes": [
         {
-          "columnNames": ["score", "submitted_at", "nickname"],
+          "columnNames": [
+            "score",
+            "submitted_at",
+            "nickname"
+          ],
           "keyName": "idx_ranking_score_submit_nickname",
           "unique": false,
           "primary": false,
@@ -763,7 +814,9 @@
           "composite": true
         },
         {
-          "columnNames": ["id"],
+          "columnNames": [
+            "id"
+          ],
           "keyName": "PRIMARY",
           "unique": true,
           "primary": true,
@@ -791,8 +844,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "user_key": {
           "name": "user_key",
@@ -807,24 +859,24 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "channel": {
           "name": "channel",
-          "type": "varchar(20)",
+          "type": "enum('contactsViral')",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
           "unique": false,
-          "length": 20,
+          "length": 13,
           "precision": null,
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
+          "enumItems": [
+            "contactsViral"
+          ]
         },
         "module_id": {
           "name": "module_id",
@@ -839,8 +891,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
+          "enumItems": []
         },
         "created_at": {
           "name": "created_at",
@@ -855,8 +906,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "updated_at": {
           "name": "updated_at",
@@ -871,35 +921,52 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         }
       },
       "indexes": [
         {
-          "columnNames": ["user_key", "created_at"],
-          "keyName": "idx_share_logs_user_created",
+          "columnNames": [
+            "id"
+          ],
+          "keyName": "PRIMARY",
+          "unique": true,
+          "primary": true,
+          "constraint": true
+        },
+        {
+          "columnNames": [
+            "user_key",
+            "created_at"
+          ],
+          "keyName": "share_logs_user_key_created_at_index",
           "unique": false,
           "primary": false,
           "constraint": false,
           "composite": true
         },
         {
-          "columnNames": ["id"],
-          "keyName": "PRIMARY",
-          "unique": true,
-          "primary": true,
-          "constraint": true
+          "columnNames": [
+            "user_key"
+          ],
+          "keyName": "share_logs_user_key_index",
+          "unique": false,
+          "primary": false,
+          "constraint": false
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "fk_share_logs_user": {
-          "columnNames": ["user_key"],
-          "constraintName": "fk_share_logs_user",
+        "share_logs_user_key_foreign": {
+          "columnNames": [
+            "user_key"
+          ],
+          "constraintName": "share_logs_user_key_foreign",
           "localTableName": "share_logs",
           "referencedTableName": "users",
-          "referencedColumnNames": ["user_key"],
+          "referencedColumnNames": [
+            "user_key"
+          ],
           "updateRule": "no action",
           "deleteRule": "no action"
         }
@@ -1018,14 +1085,18 @@
       },
       "indexes": [
         {
-          "columnNames": ["user_key"],
+          "columnNames": [
+            "user_key"
+          ],
           "keyName": "PRIMARY",
           "unique": true,
           "primary": true,
           "constraint": true
         },
         {
-          "columnNames": ["nickname"],
+          "columnNames": [
+            "nickname"
+          ],
           "keyName": "users_nickname_unique",
           "unique": true,
           "primary": false,

--- a/server-toss/src/migrations/Migration20260509000000.ts
+++ b/server-toss/src/migrations/Migration20260509000000.ts
@@ -38,13 +38,14 @@ export class Migration20260509000000 extends Migration {
       "create table if not exists `share_logs` (" +
         "`id` bigint unsigned not null auto_increment, " +
         "`user_key` int unsigned not null, " +
-        "`channel` varchar(20) not null, " +
+        "`channel` enum('contactsViral') not null, " +
         "`module_id` varchar(64) null, " +
         "`created_at` timestamp not null, " +
         "`updated_at` timestamp not null, " +
         "primary key (`id`), " +
-        "index `idx_share_logs_user_created` (`user_key`, `created_at`), " +
-        "constraint `fk_share_logs_user` foreign key (`user_key`) references `users` (`user_key`)" +
+        "index `share_logs_user_key_index` (`user_key`), " +
+        "index `share_logs_user_key_created_at_index` (`user_key`, `created_at`), " +
+        "constraint `share_logs_user_key_foreign` foreign key (`user_key`) references `users` (`user_key`)" +
         ") default character set utf8mb4 engine = InnoDB;",
     );
   }

--- a/server-toss/src/migrations/Migration20260509000000.ts
+++ b/server-toss/src/migrations/Migration20260509000000.ts
@@ -3,8 +3,30 @@ import { Migration } from "@mikro-orm/migrations";
 export class Migration20260509000000 extends Migration {
   override async up(): Promise<void> {
     await this.execute(
-      "alter table `play_chances` add column `last_reset_at` date null;",
+      "create table if not exists `play_chances` (" +
+        "`user_key` int unsigned not null, " +
+        "`count` int not null default 0, " +
+        "`last_reset_at` date not null, " +
+        "primary key (`user_key`)" +
+        ") default character set utf8mb4 engine = InnoDB;",
     );
+
+    await this.execute(
+      "set @col_exists := (" +
+        "select count(*) from information_schema.columns " +
+        "where table_schema = database() " +
+        "and table_name = 'play_chances' " +
+        "and column_name = 'last_reset_at');",
+    );
+    await this.execute(
+      "set @ddl := if(@col_exists = 0, " +
+        "'alter table `play_chances` add column `last_reset_at` date null', " +
+        "'select 1');",
+    );
+    await this.execute("prepare stmt from @ddl;");
+    await this.execute("execute stmt;");
+    await this.execute("deallocate prepare stmt;");
+
     await this.execute(
       "update `play_chances` set `last_reset_at` = current_date() where `last_reset_at` is null;",
     );
@@ -13,7 +35,7 @@ export class Migration20260509000000 extends Migration {
     );
 
     await this.execute(
-      "create table `share_logs` (" +
+      "create table if not exists `share_logs` (" +
         "`id` bigint unsigned not null auto_increment, " +
         "`user_key` int unsigned not null, " +
         "`channel` varchar(20) not null, " +


### PR DESCRIPTION
## 문제

운영 배포 시 migration 컨테이너가 다음 에러로 다운:
```
Table 'daVinci_toss.play_chances' doesn't exist
```

원인:
- `play_chances` CREATE TABLE 마이그레이션이 한 번도 작성된 적 없음 (개발자가 `pnpm seed`의 `schema:update`로 로컬 DB만 갱신)
- `Migration20260509000000`은 테이블이 이미 존재한다고 가정하고 ALTER만 수행 → 빈 운영 DB에서 실패
- `mikro-orm.migration.config.cjs` entities 배열에 `PlayChance`, `ShareLog`가 빠져 있어 자동 마이그레이션 생성 단계부터 결함

운영 로그상 `private-apps` 빌드의 `/chances/me`, `/chances/consume` 요청이 level 40으로 반복 실패 중.

## 변경

- `Migration20260509000000.ts` 멱등 재작성
  - `play_chances`: `CREATE TABLE IF NOT EXISTS` (전체 스키마)
  - `last_reset_at` ALTER: `information_schema` 가드 + `PREPARE`/`EXECUTE`로 컬럼 부재 시에만 실행
  - `share_logs`: `CREATE TABLE IF NOT EXISTS`
- `mikro-orm.migration.config.cjs` entities 배열에 `PlayChance`, `ShareLog` 추가

## 호환성

- 운영 DB(미적용): 다음 `migration:up`에서 정상 실행되어 두 테이블 모두 생성
- 로컬/개발 DB(이미 `schema:update`로 적용된 환경): `mikro_orm_migrations` 이력에 의해 재실행 안 됨, 영향 없음
- 만약 재실행되더라도 `IF NOT EXISTS`/가드로 멱등 보장

## Test plan

- [x] `pnpm test` (84/84 통과)
- [x] `pnpm lint`, `pnpm format:check`, `pnpm build` 통과
- [x] 로컬에서 `pnpm migration:up` 통과
- [ ] 배포 후 migration 컨테이너 exit 0 확인
- [ ] `private-apps` 빌드의 `/chances/*` 응답이 정상(level 30) 회복 확인