### PR TITLE
[feat] 그림 제출/랭킹 저장 트랜잭션 분리 및 롤백 테스트

### DIFF
--- a/server-toss/src/modules/drawing/drawing.module.ts
+++ b/server-toss/src/modules/drawing/drawing.module.ts
@@ -8,6 +8,7 @@ import { DrawingService } from "./service/drawing.service";
 import { DrawingAccessService } from "./service/drawing-access.service";
 import { UserModule } from "../user/user.module";
 import { RankingModule } from "../ranking/ranking.module";
+import { SaveDrawingService } from "./service/save-drawing.service";
 
 @Module({
   imports: [
@@ -18,7 +19,7 @@ import { RankingModule } from "../ranking/ranking.module";
     RankingModule,
   ],
   controllers: [DrawingController],
-  providers: [DrawingService, DrawingAccessService],
+  providers: [DrawingService, DrawingAccessService, SaveDrawingService],
   exports: [DrawingAccessService],
 })
 export class DrawingModule {}

--- a/server-toss/src/modules/drawing/dto/save-drawing.dto.ts
+++ b/server-toss/src/modules/drawing/dto/save-drawing.dto.ts
@@ -1,0 +1,14 @@
+import type { Similarity } from "@davinci/similarity";
+import type { Stroke } from "@toss/shared";
+
+export class SaveDrawingDto {
+  public readonly promptId: number;
+  public readonly strokes: Stroke[];
+  public readonly similarity: Similarity;
+
+  constructor(promptId: number, strokes: Stroke[], similarity: Similarity) {
+    this.promptId = promptId;
+    this.strokes = strokes;
+    this.similarity = similarity;
+  }
+}

--- a/server-toss/src/modules/drawing/service/drawing.service.ts
+++ b/server-toss/src/modules/drawing/service/drawing.service.ts
@@ -13,7 +13,8 @@ import { Drawing } from "../drawing.entity";
 import { DrawingAccessService } from "./drawing-access.service";
 import { DrawingRepository } from "../drawing.repository";
 import { InjectRepository } from "@mikro-orm/nestjs";
-import { RankingService } from "src/modules/ranking/ranking.service";
+import { SaveDrawingService } from "./save-drawing.service";
+import { SaveDrawingDto } from "../dto/save-drawing.dto";
 
 type Similarity = ReturnType<typeof scoreFinalSimilarity>;
 const SLOW_STROKES_DURATION_MS = 500;
@@ -34,7 +35,7 @@ export class DrawingService {
     private readonly drawingAccessService: DrawingAccessService,
     @InjectRepository(Drawing)
     private readonly drawingRepository: DrawingRepository,
-    private readonly rankingService: RankingService,
+    private readonly saveDrawingService: SaveDrawingService,
   ) {}
 
   // 획 단위 실시간 호출 엔드포인트. 클라 값 신뢰 X → 서버가 매번 유사도 재계산
@@ -100,14 +101,13 @@ export class DrawingService {
 
     const { promptId, preprocessed } =
       await this.promptService.getPreprocessedByDate(date);
+
     const playerPreprocessed = preprocessStrokes(playerStrokes);
     const similarity = scoreFinalSimilarity(preprocessed, playerPreprocessed);
-    const drawing = await this.drawingRepository.saveDrawing(
+
+    const drawing = await this.saveDrawingService.saveDrawingWithRanking(
       user,
-      promptId,
-      JSON.stringify(playerStrokes),
-      JSON.stringify(similarity),
-      similarity.score,
+      new SaveDrawingDto(promptId, playerStrokes, similarity),
     );
 
     this.logger.log(
@@ -121,7 +121,7 @@ export class DrawingService {
       },
       "최종 드로잉 제출 성공",
     );
-    await this.rankingService.updateRanking(user, drawing);
+
     const promotionGranted =
       await this.pointService.grantDrawingPromotionIfEligible(user.userKey);
 

--- a/server-toss/src/modules/drawing/service/drawing.service.ts
+++ b/server-toss/src/modules/drawing/service/drawing.service.ts
@@ -18,16 +18,6 @@ import { RankingService } from "src/modules/ranking/ranking.service";
 type Similarity = ReturnType<typeof scoreFinalSimilarity>;
 const SLOW_STROKES_DURATION_MS = 500;
 
-function getStrokeMetrics(playerStrokes: Stroke[]) {
-  const strokeCount = playerStrokes.length;
-  const pointCount = playerStrokes.reduce((total, stroke) => {
-    const [xs, ys] = stroke.points;
-    return total + Math.max(xs.length, ys.length);
-  }, 0);
-
-  return { strokeCount, pointCount };
-}
-
 function getFailureLogLevel(error: unknown): "warn" | "error" {
   if (error instanceof HttpException && error.getStatus() < 500) return "warn";
   return "error";
@@ -50,7 +40,6 @@ export class DrawingService {
   // 획 단위 실시간 호출 엔드포인트. 클라 값 신뢰 X → 서버가 매번 유사도 재계산
   async scoreStrokes(playerStrokes: Stroke[], date: Date): Promise<Similarity> {
     const startedAt = Date.now();
-    const strokeMetrics = getStrokeMetrics(playerStrokes);
     let promptId: number | undefined;
 
     try {
@@ -67,7 +56,6 @@ export class DrawingService {
         promptId,
         score: similarity.score,
         durationMs,
-        ...strokeMetrics,
       };
 
       if (durationMs >= SLOW_STROKES_DURATION_MS) {
@@ -82,7 +70,6 @@ export class DrawingService {
         event: "drawing.score.failed",
         promptId,
         durationMs: Date.now() - startedAt,
-        ...strokeMetrics,
         err,
       };
 
@@ -107,7 +94,7 @@ export class DrawingService {
     promotionGranted: boolean;
   }> {
     const startedAt = Date.now();
-    const strokeMetrics = getStrokeMetrics(playerStrokes);
+
     const user = await this.userService.getUserInfo(userKey);
     await this.drawingAccessService.validateAccess(user);
 
@@ -131,7 +118,6 @@ export class DrawingService {
         promptId,
         score: similarity.score,
         durationMs: Date.now() - startedAt,
-        ...strokeMetrics,
       },
       "최종 드로잉 제출 성공",
     );

--- a/server-toss/src/modules/drawing/service/save-drawing.service.ts
+++ b/server-toss/src/modules/drawing/service/save-drawing.service.ts
@@ -1,0 +1,37 @@
+import { RankingService } from "src/modules/ranking/ranking.service";
+import { User } from "src/modules/user/user.entity";
+import { Drawing } from "../drawing.entity";
+import { SaveDrawingDto } from "../dto/save-drawing.dto";
+import { Injectable } from "@nestjs/common";
+import { DrawingRepository } from "../drawing.repository";
+import { InjectRepository } from "@mikro-orm/nestjs";
+import { Transactional } from "@mikro-orm/decorators/legacy";
+
+@Injectable()
+export class SaveDrawingService {
+  constructor(
+    @InjectRepository(Drawing)
+    private readonly drawingRepository: DrawingRepository,
+    private readonly rankingService: RankingService,
+  ) {}
+
+  @Transactional()
+  async saveDrawingWithRanking(
+    user: User,
+    dto: SaveDrawingDto,
+  ): Promise<Drawing> {
+    const { promptId, strokes, similarity } = dto;
+
+    const drawing = await this.drawingRepository.saveDrawing(
+      user,
+      promptId,
+      JSON.stringify(strokes),
+      JSON.stringify(similarity),
+      similarity.score,
+    );
+
+    await this.rankingService.updateRanking(user, drawing);
+
+    return drawing;
+  }
+}

--- a/server-toss/src/modules/drawing/test/drawing.service.spec.ts
+++ b/server-toss/src/modules/drawing/test/drawing.service.spec.ts
@@ -20,7 +20,9 @@ jest.mock("src/common/util/time.util", () => ({
   }),
 }));
 
+import { Stroke } from "@toss/shared";
 import type { User } from "../../user/user.entity";
+import { SaveDrawingDto } from "../dto/save-drawing.dto";
 import { DrawingService } from "../service/drawing.service";
 
 const sampleStrokes = [
@@ -80,8 +82,8 @@ const buildDrawingRepository = () => ({
   findDrawingById: jest.fn(),
 });
 
-const buildRankingService = () => ({
-  updateRanking: jest.fn(),
+const buildSaveDrawingService = () => ({
+  saveDrawingWithRanking: jest.fn(),
 });
 
 const buildService = ({
@@ -90,13 +92,14 @@ const buildService = ({
   pointService = buildPointService(),
   drawingAccessService = buildDrawingAccessService(),
   drawingRepository = buildDrawingRepository(),
-  rankingService = buildRankingService(),
+  saveDrawingService = buildSaveDrawingService(),
 }: {
   userService?: ReturnType<typeof buildUserService>;
   promptService?: ReturnType<typeof buildPromptService>;
   pointService?: ReturnType<typeof buildPointService>;
   drawingAccessService?: ReturnType<typeof buildDrawingAccessService>;
   drawingRepository?: ReturnType<typeof buildDrawingRepository>;
+  saveDrawingService?: ReturnType<typeof buildSaveDrawingService>;
 }) =>
   new DrawingService(
     userService as never,
@@ -104,7 +107,7 @@ const buildService = ({
     pointService as never,
     drawingAccessService as never,
     drawingRepository as never,
-    rankingService as never,
+    saveDrawingService as never,
   );
 
 describe("DrawingService", () => {
@@ -141,8 +144,8 @@ describe("DrawingService", () => {
         getUserInfo: jest.fn(async () => fakeUser),
       };
       const drawingAccessService = buildDrawingAccessService();
-      const drawingRepository = buildDrawingRepository();
-      drawingRepository.saveDrawing.mockResolvedValue({
+      const saveDrawingService = buildSaveDrawingService();
+      saveDrawingService.saveDrawingWithRanking.mockResolvedValue({
         id: BigInt(42),
       });
 
@@ -150,7 +153,7 @@ describe("DrawingService", () => {
         userService,
         pointService: buildPointService(false),
         drawingAccessService,
-        drawingRepository,
+        saveDrawingService,
       });
 
       const result = await service.submitDrawing(
@@ -163,18 +166,17 @@ describe("DrawingService", () => {
       expect(drawingAccessService.validateAccess).toHaveBeenCalledWith(
         fakeUser,
       );
-      expect(drawingRepository.saveDrawing).toHaveBeenCalledTimes(1);
-      expect(drawingRepository.saveDrawing).toHaveBeenCalledWith(
+      expect(saveDrawingService.saveDrawingWithRanking).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(saveDrawingService.saveDrawingWithRanking).toHaveBeenCalledWith(
         fakeUser,
-        7,
-        JSON.stringify(sampleStrokes),
-        JSON.stringify({
+        new SaveDrawingDto(7, sampleStrokes as Stroke[], {
           score: 87,
           strokeMatchSimilarity: 85,
           shapeSimilarity: 88,
           penalty: 5,
         }),
-        87,
       );
       expect(result).toMatchObject({
         drawingId: 42,
@@ -198,11 +200,40 @@ describe("DrawingService", () => {
       expect(drawingRepository.saveDrawing).not.toHaveBeenCalled();
     });
 
+    it("그림 저장에 실패하면, 포인트 지급이 되지 않는다", async () => {
+      const pointService = buildPointService(true);
+      const saveDrawingService = buildSaveDrawingService();
+      saveDrawingService.saveDrawingWithRanking.mockRejectedValue(
+        new Error("SAVE_FAILED"),
+      );
+
+      const service = buildService({
+        pointService,
+        saveDrawingService,
+      });
+
+      await expect(
+        service.submitDrawing(1234, sampleStrokes as never, new Date()),
+      ).rejects.toThrow("SAVE_FAILED");
+      expect(
+        pointService.grantDrawingPromotionIfEligible,
+      ).not.toHaveBeenCalled();
+    });
+
     it("프로모션 지급은 PointService에 위임하고 결과를 그대로 반환한다", async () => {
       const pointService = buildPointService(true);
       const drawingRepository = buildDrawingRepository();
+      const saveDrawingService = buildSaveDrawingService();
+      saveDrawingService.saveDrawingWithRanking.mockResolvedValue({
+        id: BigInt(1),
+      });
       drawingRepository.saveDrawing.mockResolvedValue({ id: BigInt(1) });
-      const service = buildService({ pointService, drawingRepository });
+
+      const service = buildService({
+        pointService,
+        drawingRepository,
+        saveDrawingService,
+      });
 
       const result = await service.submitDrawing(
         1234,

--- a/server-toss/src/modules/drawing/test/save-drawing.service.test.ts
+++ b/server-toss/src/modules/drawing/test/save-drawing.service.test.ts
@@ -1,0 +1,233 @@
+import { MikroORM } from "@mikro-orm/mysql";
+import { MikroOrmModule } from "@mikro-orm/nestjs";
+import { Test, TestingModule } from "@nestjs/testing";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import { Stroke } from "@toss/shared";
+import config from "src/mikro-orm.config";
+import { Prompt } from "src/modules/prompt/prompt.entity";
+import { User } from "src/modules/user/user.entity";
+import { SmallUserDrawingSeeder } from "src/seeders/small-user-drawing.seeder";
+import { SaveDrawingDto } from "../dto/save-drawing.dto";
+import { Drawing } from "../drawing.entity";
+import { DrawingRepository } from "../drawing.repository";
+import { Ranking } from "../../ranking/ranking.entity";
+import { RankingRepository } from "../../ranking/ranking.repository";
+import { RankingService } from "../../ranking/ranking.service";
+import { SaveDrawingService } from "../service/save-drawing.service";
+
+describe("SaveDrawingService", () => {
+  let orm: MikroORM;
+  let module: TestingModule;
+  let service: SaveDrawingService;
+  let rankingService: RankingService;
+  let drawingRepository: DrawingRepository;
+  let rankingRepository: RankingRepository;
+
+  let givenUsers: User[];
+  let givenPrompt: Prompt;
+
+  const sampleStrokes: Stroke[] = [
+    {
+      points: [
+        [0, 1],
+        [0, 1],
+      ],
+      color: [0, 0, 0],
+    },
+  ];
+
+  const sampleSimilarity = {
+    score: 87,
+    strokeMatchSimilarity: 85,
+    shapeSimilarity: 88,
+    penalty: 5,
+  };
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        MikroOrmModule.forRoot(config),
+        MikroOrmModule.forFeature({ entities: [Drawing, Ranking] }),
+      ],
+      providers: [SaveDrawingService, RankingService],
+    }).compile();
+
+    service = module.get<SaveDrawingService>(SaveDrawingService);
+    rankingService = module.get<RankingService>(RankingService);
+    drawingRepository = module.get<DrawingRepository>(DrawingRepository);
+    rankingRepository = module.get<RankingRepository>(RankingRepository);
+    orm = module.get<MikroORM>(MikroORM);
+    (service as unknown as { em: unknown }).em = orm.em;
+    (rankingService as unknown as { em: unknown }).em = orm.em;
+
+    await orm.schema.refresh();
+    await orm.seeder.seed(SmallUserDrawingSeeder);
+
+    const readEm = orm.em.fork();
+    givenUsers = await readEm.findAll(User, { limit: 10 });
+    givenPrompt = await readEm.findOneOrFail(Prompt, { id: BigInt(1) });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await orm.schema.refresh();
+    await orm.close();
+    await module.close();
+  });
+
+  describe("saveDrawingWithRanking", () => {
+    describe("그림 저장에 실패하면", () => {
+      it("랭킹 갱신을 호출하지 않는다", async () => {
+        const user = givenUsers[0];
+        jest
+          .spyOn(drawingRepository, "saveDrawing")
+          .mockRejectedValue(new Error("DRAWING_SAVE_FAILED"));
+        const updateRankingSpy = jest.spyOn(rankingService, "updateRanking");
+
+        await expect(
+          service.saveDrawingWithRanking(
+            user,
+            new SaveDrawingDto(
+              Number(givenPrompt.id),
+              sampleStrokes,
+              sampleSimilarity,
+            ),
+          ),
+        ).rejects.toThrow("DRAWING_SAVE_FAILED");
+
+        expect(updateRankingSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("랭킹 저장에 실패하면", () => {
+      it("그림 제출이 롤백된다", async () => {
+        const user = givenUsers[1];
+        jest
+          .spyOn(rankingRepository, "saveOne")
+          .mockRejectedValue(new Error("RANKING_SAVE_FAILED"));
+
+        const beforeCount = await orm.em
+          .fork()
+          .count(Drawing, { user: user.userKey });
+        const beforeRankingCount = await orm.em
+          .fork()
+          .count(Ranking, { userKey: user.userKey });
+
+        await expect(
+          service.saveDrawingWithRanking(
+            user,
+            new SaveDrawingDto(
+              Number(givenPrompt.id),
+              sampleStrokes,
+              sampleSimilarity,
+            ),
+          ),
+        ).rejects.toThrow("RANKING_SAVE_FAILED");
+
+        const afterCount = await orm.em
+          .fork()
+          .count(Drawing, { user: user.userKey });
+        const afterRankingCount = await orm.em
+          .fork()
+          .count(Ranking, { userKey: user.userKey });
+
+        expect(afterCount).toBe(beforeCount);
+        expect(afterRankingCount).toBe(beforeRankingCount);
+      });
+    });
+
+    describe("정상 처리되면", () => {
+      it("drawing과 ranking이 함께 커밋된다", async () => {
+        const user = givenUsers[2];
+
+        const beforeDrawingCount = await orm.em
+          .fork()
+          .count(Drawing, { user: user.userKey });
+        const beforeRankingCount = await orm.em
+          .fork()
+          .count(Ranking, { userKey: user.userKey });
+
+        const saved = await service.saveDrawingWithRanking(
+          user,
+          new SaveDrawingDto(
+            Number(givenPrompt.id),
+            sampleStrokes,
+            sampleSimilarity,
+          ),
+        );
+
+        const afterDrawingCount = await orm.em
+          .fork()
+          .count(Drawing, { user: user.userKey });
+        const afterRankingCount = await orm.em
+          .fork()
+          .count(Ranking, { userKey: user.userKey });
+        const savedRanking = await orm.em
+          .fork()
+          .findOneOrFail(Ranking, { userKey: user.userKey });
+
+        expect(afterDrawingCount).toBe(beforeDrawingCount + 1);
+        expect(afterRankingCount).toBe(beforeRankingCount + 1);
+        expect(savedRanking.drawingId).toBe(saved.id);
+        expect(savedRanking.score).toBe(sampleSimilarity.score);
+      });
+    });
+
+    describe("기존 ranking 업데이트 중 실패하면", () => {
+      it("drawing 제출도 롤백된다", async () => {
+        const user = givenUsers[3];
+        const existingDrawing = await orm.em
+          .fork()
+          .findOneOrFail(
+            Drawing,
+            { user: user.userKey },
+            { orderBy: { id: "ASC" } },
+          );
+        await rankingRepository.saveOne(user, existingDrawing);
+
+        const beforeDrawingCount = await orm.em
+          .fork()
+          .count(Drawing, { user: user.userKey });
+        const beforeRanking = await orm.em
+          .fork()
+          .findOneOrFail(Ranking, { userKey: user.userKey });
+
+        jest.spyOn(Ranking.prototype, "update").mockImplementation(() => {
+          throw new Error("RANKING_UPDATE_FAILED");
+        });
+
+        await expect(
+          service.saveDrawingWithRanking(
+            user,
+            new SaveDrawingDto(Number(givenPrompt.id), sampleStrokes, {
+              ...sampleSimilarity,
+              score: 999,
+            }),
+          ),
+        ).rejects.toThrow("RANKING_UPDATE_FAILED");
+
+        const afterDrawingCount = await orm.em
+          .fork()
+          .count(Drawing, { user: user.userKey });
+        const afterRanking = await orm.em
+          .fork()
+          .findOneOrFail(Ranking, { id: beforeRanking.id });
+
+        expect(afterDrawingCount).toBe(beforeDrawingCount);
+        expect(afterRanking.drawingId).toBe(beforeRanking.drawingId);
+        expect(afterRanking.score).toBe(beforeRanking.score);
+      });
+    });
+  });
+});

--- a/server-toss/src/modules/ranking/ranking.service.ts
+++ b/server-toss/src/modules/ranking/ranking.service.ts
@@ -13,6 +13,7 @@ import {
 import { Ranking } from "./ranking.entity";
 import { Drawing } from "../drawing/drawing.entity";
 import { User } from "../user/user.entity";
+import { Transactional } from "@mikro-orm/decorators/legacy";
 
 @Injectable()
 export class RankingService {
@@ -21,6 +22,7 @@ export class RankingService {
     private readonly rankingRepository: RankingRepository,
   ) {}
 
+  @Transactional()
   async updateRanking(user: User, drawing: Drawing) {
     const existing = await this.rankingRepository.findByUserKey(user.userKey);
 


### PR DESCRIPTION
## 개요

그림 제출(`drawing`)과 랭킹 갱신(`ranking`)이 분리 저장되면서 부분 성공 가능성이 있어, 저장 일관성을 보장하도록 트랜잭션 경계를 분리/강화했습니다.
## 관련 이슈
- Closes #361 

## 변경 사항
- `SaveDrawingService` 
  - `saveDrawingWithRanking()`에 `@Transactional()` 적용
  - drawing 저장 + ranking 갱신을 하나의 트랜잭션으로 처리
- `DrawingService.submitDrawing()` 리팩터링
  - 저장 로직을 `SaveDrawingService`로 위임
- `RankingService.updateRanking()`에 `@Transactional()` 적용
- `SaveDrawingDto` 추가
  - `promptId`, `strokes`, `similarity`를 명시적으로 전달
- `DrawingModule` 의존성 정리
  - `SaveDrawingService` 등록 및 `RankingModule` 연계

### 체크리스트

<!-- 리뷰 전에 본인이 확인해야 하는 항목 -->

- [ ] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [ ] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [ ] 주석/변수명 등 가독성을 고려했습니다.
- [ ] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [ ] API, DB 변경 시 문서화했습니다.
- [ ] 새로운 의존성 추가 시 팀과 공유했습니다.

## 테스트 및 검증 내용

- 단위 테스트
  - `submitDrawing`에서 그림 저장 실패 시 포인트 미지급 검증 추가
<img width="535" height="330" alt="스크린샷 2026-05-11 13 03 59" src="https://github.com/user-attachments/assets/4659c054-ed9c-4a51-a4c6-4a14fe0ccd7a" />

- 통합 테스트(`save-drawing.service.test.ts`) 추가
<img width="535" height="115" alt="스크린샷 2026-05-11 13 04 16" src="https://github.com/user-attachments/assets/875209c8-e94b-4423-9bac-75ab431daf30" />


## AI 활용 점검

> AI를 어떻게 활용했는지 적어주세요.

## 추가 참고 사항

> 리뷰어가 알아야 할 특이사항, 주의사항 등을 적어주세요.

## 스크린샷 / UI 변경 (선택)

> UI가 변경된 경우 스크린샷을 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 드로잉 제출 프로세스의 안정성을 개선했습니다.
  * 드로잉 저장과 랭킹 업데이트 간의 데이터 동기화를 강화하여 트랜잭션 처리를 최적화했습니다.

* **Tests**
  * 드로잉 제출 워크플로우에 대한 포괄적인 테스트 커버리지를 추가했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boostcampwm2025/web04-we-are-all-da-Vinci/pull/362)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->