### PR TITLE
[fix] chance 일일 reset 미동작으로 자동 진입 실패 hotfix

### DIFF
--- a/server-toss/src/modules/chance/chance.service.ts
+++ b/server-toss/src/modules/chance/chance.service.ts
@@ -169,7 +169,10 @@ export class ChanceService {
       return created;
     }
 
-    if (existing.lastResetAt < start) {
+    // MikroORM date 컬럼은 driver에 따라 string("YYYY-MM-DD")으로 매핑되어
+    // Date 객체와 직접 비교 시 NaN으로 떨어져 reset 분기를 못 탐. Date로 정규화 후 비교.
+    const lastResetTime = new Date(existing.lastResetAt).getTime();
+    if (lastResetTime < start.getTime()) {
       existing.count = Math.max(existing.count, 1);
       existing.lastResetAt = start;
     }


### PR DESCRIPTION
## 개요
- `PlayChance.lastResetAt`이 MikroORM date 컬럼 매핑 결과 string으로 들어오면서 `existing.lastResetAt < start`(Date) 비교가 NaN으로 떨어져 새 날에도 reset 분기를 못 타 `count=0`이 유지됨.
- client-toss는 `consume` 409 응답을 silent return으로 흡수하므로 사용자는 자동 진입이 실패하면서 에러도 없는 상태였음.
- `new Date(existing.lastResetAt).getTime() < start.getTime()` 으로 정규화하여 string/Date 모두 안전하게 비교.

## 변경 사항
- `server-toss/src/modules/chance/play-chance.entity.ts:21` 의 `@Property({ type: "date" })` 컬럼이 driver에 따라 `"YYYY-MM-DD"` string으로 반환됨.
- TS 시그니처는 `Date`라 컴파일은 통과하나, 런타임 비교에서 string vs Date → 양쪽 `Number()` coerce → `NaN < x` = `false`.
- DB에 `last_reset_at = 2026-05-10`, `count = 0` 박혀있는 사용자도 오늘(5-12) reset 안 됐음을 직접 확인.