### PR TITLE
[fix] 게임 시작 플로우 통합

### DIFF
--- a/client-toss/src/entities/ranking/ui/MyRankingNotSubmitted.tsx
+++ b/client-toss/src/entities/ranking/ui/MyRankingNotSubmitted.tsx
@@ -1,6 +1,5 @@
 import type { PlayChanceLayoutContext } from "@/app/layouts/PlayChanceLayout";
 import { useRewardAd } from "@/feature/playChance";
-import { serverTossApi } from "@/shared/api";
 import { AD_GROUP_IDS } from "@/shared/config";
 import { getAnonymousHash } from "@/shared/lib";
 import { Button, Toast } from "@toss/tds-mobile";
@@ -30,16 +29,19 @@ const MyRankingNotSubmitted = () => {
         await showAd();
         await chargeByAd({ adGroupId: AD_GROUP_IDS.REWARDED });
       }
-      const started = await startPlay();
-      if (!started) {
+      const prompt = await startPlay();
+      if (!prompt) {
         showToast("그리기 기회가 부족해요. 잠시 후 다시 시도해주세요.");
         return;
       }
 
       const hash = await getAnonymousHash();
-      const { promptId, strokes } = await serverTossApi.getPrompt();
       navigate("/memorize", {
-        state: { promptId, promptStrokes: strokes, anonymousHash: hash },
+        state: {
+          promptId: prompt.promptId,
+          promptStrokes: prompt.strokes,
+          anonymousHash: hash,
+        },
         replace: true,
       });
     } catch (err) {

--- a/client-toss/src/feature/playChance/hooks/usePlayChance.ts
+++ b/client-toss/src/feature/playChance/hooks/usePlayChance.ts
@@ -89,7 +89,7 @@ export const usePlayChance = () => {
       if (unknownError instanceof RequestError && unknownError.status === 409) {
         return null;
       }
-      const error = toError(unknownError, "寃뚯엫 ?쒖옉???ㅽ뙣?덉뼱??");
+      const error = toError(unknownError, "게임 시작에 실패했어요");
       setState((prev) => ({ ...prev, error }));
       throw error;
     }

--- a/client-toss/src/feature/playChance/hooks/usePlayChance.ts
+++ b/client-toss/src/feature/playChance/hooks/usePlayChance.ts
@@ -1,7 +1,14 @@
 import { RequestError, serverTossApi } from "@/shared/api";
-import type { AdSdkPayload, ShareSdkPayload } from "@toss/shared";
+import type {
+  AdSdkPayload,
+  PromptResponse,
+  ShareSdkPayload,
+} from "@toss/shared";
 import { useCallback, useEffect, useState } from "react";
-import { startPlaySession } from "../model/playSessionStorage";
+import {
+  clearPlaySession,
+  startPlaySession,
+} from "../model/playSessionStorage";
 
 interface PlayChanceHookState {
   count: number;
@@ -60,17 +67,33 @@ export const usePlayChance = () => {
     }
   }, []);
 
-  const startPlay = useCallback(async () => {
+  const startPlay = useCallback(async (): Promise<PromptResponse | null> => {
     // localStorage 세션 기록을 먼저, 성공 시에만 서버 차감 — 실패 시 chance가 손실되지 않게 순서를 뒤집음
     try {
       await startPlaySession();
     } catch (unknownError) {
       const error = toError(unknownError, "플레이 세션을 저장하지 못했어요.");
       setState((prev) => ({ ...prev, error }));
-      return false;
+      return null;
     }
-    return await consume();
-  }, [consume]);
+    try {
+      const prompt = await serverTossApi.startPlay();
+      setState((prev) => ({
+        ...prev,
+        count: Math.max(prev.count - 1, 0),
+        error: null,
+      }));
+      return prompt;
+    } catch (unknownError) {
+      await clearPlaySession().catch(() => {});
+      if (unknownError instanceof RequestError && unknownError.status === 409) {
+        return null;
+      }
+      const error = toError(unknownError, "寃뚯엫 ?쒖옉???ㅽ뙣?덉뼱??");
+      setState((prev) => ({ ...prev, error }));
+      throw error;
+    }
+  }, []);
 
   useEffect(() => {
     let isMounted = true;

--- a/client-toss/src/shared/api/serverToss.ts
+++ b/client-toss/src/shared/api/serverToss.ts
@@ -169,6 +169,9 @@ export const serverTossApi = {
   getPrompt: async () =>
     PromptResponseSchema.parse(await request<unknown>("GET", "/prompt")),
 
+  startPlay: async () =>
+    PromptResponseSchema.parse(await request<unknown>("POST", "/plays/start")),
+
   scoreStrokes: async (body: SubmitStrokesRequest) =>
     SimilarityResponseSchema.parse(
       await request<unknown>("POST", "/strokes", body),

--- a/client-toss/src/views/dashboard/ui/DashboardView.test.tsx
+++ b/client-toss/src/views/dashboard/ui/DashboardView.test.tsx
@@ -1,5 +1,4 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
-import { serverTossApi } from "@/shared/api";
 import { formatLocalDate } from "@/shared/lib";
 import { getDeviceId } from "@apps-in-toss/web-framework";
 import { render, screen, waitFor } from "@testing-library/react";
@@ -10,7 +9,10 @@ import DashboardView from "./DashboardView";
 import MyDrawingsPanel from "./MyDrawingsPanel";
 
 const navigateMock = vi.fn();
-const mockStartPlay = vi.fn().mockResolvedValue(true);
+const mockStartPlay = vi.fn().mockResolvedValue({
+  promptId: 42,
+  strokes: [{ points: [[1], [2]], color: [0, 0, 0] }],
+});
 const mockChargeByAd = vi.fn().mockResolvedValue(1);
 const mockRefresh = vi.fn().mockResolvedValue(1);
 vi.mock("react-router-dom", async () => {
@@ -107,11 +109,6 @@ describe("DashboardView", () => {
   });
 
   it("첫 방문 시 getPrompt 호출 후 /memorize로 이동한다", async () => {
-    vi.mocked(serverTossApi.getPrompt).mockResolvedValue({
-      promptId: 42,
-      strokes: [{ points: [[1], [2]], color: [0, 0, 0] }],
-    });
-
     renderDashboard();
 
     // 초기에는 "준비 중..." 로딩 표시
@@ -130,9 +127,7 @@ describe("DashboardView", () => {
   });
 
   it("getPrompt 실패 시 에러 메시지와 재시도 버튼을 표시한다", async () => {
-    vi.mocked(serverTossApi.getPrompt).mockRejectedValue(
-      new Error("네트워크 오류"),
-    );
+    mockStartPlay.mockRejectedValueOnce(new Error("네트워크 오류"));
 
     renderDashboard();
 
@@ -147,7 +142,7 @@ describe("DashboardView", () => {
 
   it("다시 시도 클릭 시 getPrompt를 재호출한다", async () => {
     const user = userEvent.setup();
-    vi.mocked(serverTossApi.getPrompt)
+    mockStartPlay
       .mockRejectedValueOnce(new Error("실패"))
       .mockResolvedValueOnce({
         promptId: 1,
@@ -163,7 +158,7 @@ describe("DashboardView", () => {
     await user.click(screen.getByText("다시 시도해요"));
 
     await waitFor(() => {
-      expect(serverTossApi.getPrompt).toHaveBeenCalledTimes(2);
+      expect(mockStartPlay).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -177,12 +172,12 @@ describe("DashboardView", () => {
       expect(screen.getByTestId("my-ranking-section")).toBeInTheDocument();
     });
 
-    expect(serverTossApi.getPrompt).not.toHaveBeenCalled();
+    expect(mockStartPlay).not.toHaveBeenCalled();
   });
 
   it("getDeviceId 실패 시 local 폴백으로 동작한다", async () => {
     vi.mocked(getDeviceId).mockRejectedValue(new Error("미지원"));
-    vi.mocked(serverTossApi.getPrompt).mockResolvedValue({
+    mockStartPlay.mockResolvedValueOnce({
       promptId: 1,
       strokes: [],
     });
@@ -229,7 +224,7 @@ describe("DashboardView", () => {
     localStorage.setItem("lastPlayed_test-device", today);
     const user = userEvent.setup();
 
-    vi.mocked(serverTossApi.getPrompt).mockResolvedValue({
+    mockStartPlay.mockResolvedValueOnce({
       promptId: 99,
       strokes: [],
     });

--- a/client-toss/src/views/dashboard/ui/DashboardView.tsx
+++ b/client-toss/src/views/dashboard/ui/DashboardView.tsx
@@ -70,17 +70,16 @@ const DashboardView = () => {
     setIsStartingGame(true);
     setError(null);
     try {
-      const started = await startPlay();
-      if (!started) {
+      const prompt = await startPlay();
+      if (!prompt) {
         setIsStartingGame(false);
         return;
       }
 
-      const { promptId, strokes } = await serverTossApi.getPrompt();
       navigate("/memorize", {
         state: {
-          promptId,
-          promptStrokes: strokes,
+          promptId: prompt.promptId,
+          promptStrokes: prompt.strokes,
           anonymousHash: anonymousHashRef.current,
         },
         replace: true,
@@ -149,8 +148,8 @@ const DashboardView = () => {
         await showAd();
         await chargeByAd({ adGroupId: AD_GROUP_IDS.REWARDED });
       }
-      const started = await startPlay();
-      if (!started) {
+      const prompt = await startPlay();
+      if (!prompt) {
         await refreshChance();
         setToastText(
           "그리기 기회를 다시 확인했어요. 잠시 후 다시 시도해주세요.",
@@ -159,11 +158,10 @@ const DashboardView = () => {
         return;
       }
 
-      const { promptId, strokes } = await serverTossApi.getPrompt();
       navigate("/memorize", {
         state: {
-          promptId,
-          promptStrokes: strokes,
+          promptId: prompt.promptId,
+          promptStrokes: prompt.strokes,
           anonymousHash: anonymousHashRef.current,
         },
         replace: true,

--- a/client-toss/src/views/submitted/ui/SubmittedView.test.tsx
+++ b/client-toss/src/views/submitted/ui/SubmittedView.test.tsx
@@ -9,7 +9,10 @@ import SubmittedView from "./SubmittedView";
 
 const navigateMock = vi.fn();
 const mockChargeByAd = vi.fn().mockResolvedValue(1);
-const mockStartPlay = vi.fn().mockResolvedValue(true);
+const mockStartPlay = vi.fn().mockResolvedValue({
+  promptId: 42,
+  strokes: [{ points: [[1], [2]], color: [0, 0, 0] }],
+});
 vi.mock("react-router-dom", async () => {
   const actual =
     await vi.importActual<typeof import("react-router-dom")>(
@@ -176,18 +179,12 @@ describe("SubmittedView", () => {
   it("다시하기 클릭 시 charge → startPlay → getPrompt를 호출한다", async () => {
     vi.useRealTimers();
     const user = userEvent.setup();
-    vi.mocked(serverTossApi.getPrompt).mockResolvedValue({
-      promptId: 42,
-      strokes: [{ points: [[1], [2]], color: [0, 0, 0] }],
-    });
-
     renderWithState();
 
     await user.click(screen.getByText("광고·등록 없이 재도전"));
 
     await waitFor(() => {
       expect(mockStartPlay).toHaveBeenCalled();
-      expect(serverTossApi.getPrompt).toHaveBeenCalled();
     });
 
     await waitFor(() => {
@@ -230,7 +227,7 @@ describe("SubmittedView", () => {
   it("다시하기 시 startPlay가 false 반환하면 부족 토스트를 표시하고 네비게이션하지 않는다", async () => {
     vi.useRealTimers();
     const user = userEvent.setup();
-    mockStartPlay.mockResolvedValueOnce(false);
+    mockStartPlay.mockResolvedValueOnce(null);
 
     renderWithState();
 
@@ -247,9 +244,7 @@ describe("SubmittedView", () => {
   it("다시하기 시 getPrompt 실패하면 에러 토스트를 표시한다", async () => {
     vi.useRealTimers();
     const user = userEvent.setup();
-    vi.mocked(serverTossApi.getPrompt).mockRejectedValueOnce(
-      new Error("프롬프트 실패"),
-    );
+    mockStartPlay.mockRejectedValueOnce(new Error("프롬프트 실패"));
 
     renderWithState();
 
@@ -267,7 +262,7 @@ describe("SubmittedView", () => {
       showAd: mockShowAd,
     }));
     const user = userEvent.setup();
-    vi.mocked(serverTossApi.getPrompt).mockResolvedValue({
+    mockStartPlay.mockResolvedValueOnce({
       promptId: 7,
       strokes: [],
     });
@@ -292,7 +287,7 @@ describe("SubmittedView", () => {
   it("광고가 로드되지 않은 경우 다시하기 시 광고/chargeByAd 없이 startPlay만 호출한다", async () => {
     vi.useRealTimers();
     const user = userEvent.setup();
-    vi.mocked(serverTossApi.getPrompt).mockResolvedValue({
+    mockStartPlay.mockResolvedValueOnce({
       promptId: 8,
       strokes: [],
     });

--- a/client-toss/src/views/submitted/ui/SubmittedView.tsx
+++ b/client-toss/src/views/submitted/ui/SubmittedView.tsx
@@ -66,19 +66,18 @@ const SubmittedView = () => {
         await showAd();
         await chargeByAd({ adGroupId: AD_GROUP_IDS.REWARDED });
       }
-      const started = await startPlay();
-      if (!started) {
+      const prompt = await startPlay();
+      if (!prompt) {
         setToastText("그리기 기회가 부족해요.");
         setToastOpen(true);
         setIsReplaying(false);
         return;
       }
 
-      const { promptId, strokes } = await serverTossApi.getPrompt();
       navigate("/memorize", {
         state: {
-          promptId,
-          promptStrokes: strokes,
+          promptId: prompt.promptId,
+          promptStrokes: prompt.strokes,
           anonymousHash: routeState?.anonymousHash ?? "local",
         },
         replace: true,

--- a/server-toss/src/app.module.ts
+++ b/server-toss/src/app.module.ts
@@ -12,6 +12,7 @@ import { AuthModule } from "./modules/auth/auth.module";
 import { ChanceModule } from "./modules/chance/chance.module";
 import { DrawingModule } from "./modules/drawing/drawing.module";
 import { PointModule } from "./modules/point/point.module";
+import { PlayModule } from "./modules/play/play.module";
 import { PromptModule } from "./modules/prompt/prompt.module";
 import { RankingModule } from "./modules/ranking/ranking.module";
 import { UserModule } from "./modules/user/user.module";
@@ -40,6 +41,7 @@ import { UserModule } from "./modules/user/user.module";
     DrawingModule,
     PromptModule,
     PointModule,
+    PlayModule,
     AdModule,
     ChanceModule,
     RankingModule,

--- a/server-toss/src/modules/chance/chance.module.ts
+++ b/server-toss/src/modules/chance/chance.module.ts
@@ -11,5 +11,6 @@ import { ShareLog } from "./share-log.entity";
   imports: [MikroOrmModule.forFeature([PlayChance, ShareLog, AdView, User])],
   controllers: [ChanceController],
   providers: [ChanceService],
+  exports: [ChanceService],
 })
 export class ChanceModule {}

--- a/server-toss/src/modules/chance/chance.service.ts
+++ b/server-toss/src/modules/chance/chance.service.ts
@@ -137,18 +137,25 @@ export class ChanceService {
   }
 
   async consume(userKey: number): Promise<{ count: number }> {
-    return this.em.transactional(async (em) => {
-      const chance = await this.getOrInitWithReset(em, userKey);
+    return this.em.transactional((em) =>
+      this.consumeWithEntityManager(em, userKey),
+    );
+  }
 
-      if (chance.count <= 0) {
-        this.denyLog(userKey, "consume", "no_chance");
-        throw new ConflictException("그리기 기회가 부족해요.");
-      }
+  async consumeWithEntityManager(
+    em: EntityManager,
+    userKey: number,
+  ): Promise<{ count: number }> {
+    const chance = await this.getOrInitWithReset(em, userKey);
 
-      chance.count -= 1;
-      this.successLog(userKey, "consume", chance.count);
-      return { count: chance.count };
-    });
+    if (chance.count <= 0) {
+      this.denyLog(userKey, "consume", "no_chance");
+      throw new ConflictException("그리기 기회가 부족해요.");
+    }
+
+    chance.count -= 1;
+    this.successLog(userKey, "consume", chance.count);
+    return { count: chance.count };
   }
 
   private async getOrInitWithReset(

--- a/server-toss/src/modules/drawing/drawing.module.ts
+++ b/server-toss/src/modules/drawing/drawing.module.ts
@@ -8,6 +8,7 @@ import { DrawingService } from "./service/drawing.service";
 import { DrawingAccessService } from "./service/drawing-access.service";
 import { UserModule } from "../user/user.module";
 import { RankingModule } from "../ranking/ranking.module";
+import { ChanceModule } from "../chance/chance.module";
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { RankingModule } from "../ranking/ranking.module";
     UserModule,
     PointModule,
     RankingModule,
+    ChanceModule,
   ],
   controllers: [DrawingController],
   providers: [DrawingService, DrawingAccessService],

--- a/server-toss/src/modules/drawing/service/drawing-access.service.ts
+++ b/server-toss/src/modules/drawing/service/drawing-access.service.ts
@@ -1,29 +1,25 @@
-import { EntityManager } from "@mikro-orm/mysql";
 import { BadRequestException, Injectable, Logger } from "@nestjs/common";
 import { User } from "src/modules/user/user.entity";
-import { Drawing } from "../drawing.entity";
-import { getSeoulDayRange } from "src/common/util/time.util";
-import { AdType, AdView } from "src/modules/ad/ad-view.entity";
+import { ChanceService } from "src/modules/chance/chance.service";
 
 @Injectable()
 export class DrawingAccessService {
   private readonly logger = new Logger(DrawingAccessService.name);
-  private readonly DEFAULT_DRAWING_COUNT = 1;
 
-  constructor(private readonly em: EntityManager) {}
+  constructor(private readonly chanceService: ChanceService) {}
 
   async canAccess(user: User) {
     return (await this.getAccessStatus(user)).allowed;
   }
 
   async validateAccess(user: User): Promise<void> {
-    if (process.env.NODE_ENV === "development") {
-      this.logger.debug(
-        { event: "drawing.access.bypass_dev", userKey: user.userKey },
-        "개발환경 그림 제출 기회 검증 우회",
-      );
-      return;
-    }
+    // if (process.env.NODE_ENV === "development") {
+    //   this.logger.debug(
+    //     { event: "drawing.access.bypass_dev", userKey: user.userKey },
+    //     "개발환경 그림 제출 기회 검증 우회",
+    //   );
+    //   return;
+    // }
 
     const accessStatus = await this.getAccessStatus(user);
     if (!accessStatus.allowed) {
@@ -31,8 +27,7 @@ export class DrawingAccessService {
         {
           event: "drawing.access.denied",
           userKey: user.userKey,
-          drawingCount: accessStatus.drawingCount,
-          adViewCount: accessStatus.adViewCount,
+          chanceCount: accessStatus.chanceCount,
         },
         "그림 제출 기회 부족",
       );
@@ -41,26 +36,9 @@ export class DrawingAccessService {
   }
 
   private async getAccessStatus(user: User) {
-    const { start, end } = getSeoulDayRange();
+    const { count } = await this.chanceService.getMyChance(user.userKey);
+    const allowed = count > 0;
 
-    const drawingCount = await this.em.count(Drawing, {
-      user,
-      createdAt: {
-        $gte: start,
-        $lt: end,
-      },
-    });
-
-    const adViewCount = await this.em.count(AdView, {
-      user,
-      type: AdType.DRAWING,
-      createdAt: {
-        $gte: start,
-        $lt: end,
-      },
-    });
-    const allowed = drawingCount < this.DEFAULT_DRAWING_COUNT + adViewCount;
-
-    return { allowed, drawingCount, adViewCount };
+    return { allowed, chanceCount: count };
   }
 }

--- a/server-toss/src/modules/drawing/service/drawing-access.service.ts
+++ b/server-toss/src/modules/drawing/service/drawing-access.service.ts
@@ -13,13 +13,13 @@ export class DrawingAccessService {
   }
 
   async validateAccess(user: User): Promise<void> {
-    // if (process.env.NODE_ENV === "development") {
-    //   this.logger.debug(
-    //     { event: "drawing.access.bypass_dev", userKey: user.userKey },
-    //     "개발환경 그림 제출 기회 검증 우회",
-    //   );
-    //   return;
-    // }
+    if (process.env.NODE_ENV === "development") {
+      this.logger.debug(
+        { event: "drawing.access.bypass_dev", userKey: user.userKey },
+        "개발환경 그림 제출 기회 검증 우회",
+      );
+      return;
+    }
 
     const accessStatus = await this.getAccessStatus(user);
     if (!accessStatus.allowed) {

--- a/server-toss/src/modules/drawing/service/drawing.service.ts
+++ b/server-toss/src/modules/drawing/service/drawing.service.ts
@@ -10,7 +10,6 @@ import { PointService } from "src/modules/point/point.service";
 import { UserService } from "src/modules/user/user.service";
 import { PromptService } from "../../prompt/prompt.service";
 import { Drawing } from "../drawing.entity";
-import { DrawingAccessService } from "./drawing-access.service";
 import { DrawingRepository } from "../drawing.repository";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { RankingService } from "src/modules/ranking/ranking.service";
@@ -41,7 +40,6 @@ export class DrawingService {
     private readonly userService: UserService,
     private readonly promptService: PromptService,
     private readonly pointService: PointService,
-    private readonly drawingAccessService: DrawingAccessService,
     @InjectRepository(Drawing)
     private readonly drawingRepository: DrawingRepository,
     private readonly rankingService: RankingService,
@@ -109,7 +107,6 @@ export class DrawingService {
     const startedAt = Date.now();
     const strokeMetrics = getStrokeMetrics(playerStrokes);
     const user = await this.userService.getUserInfo(userKey);
-    await this.drawingAccessService.validateAccess(user);
 
     const { promptId, preprocessed } =
       await this.promptService.getPreprocessedByDate(date);

--- a/server-toss/src/modules/drawing/test/drawing-access.service.spec.ts
+++ b/server-toss/src/modules/drawing/test/drawing-access.service.spec.ts
@@ -1,63 +1,37 @@
-jest.mock("src/common/util/time.util", () => ({
-  getSeoulDayRange: () => ({
-    start: new Date("2026-05-03T15:00:00.000Z"),
-    end: new Date("2026-05-04T15:00:00.000Z"),
-  }),
-}));
-
 import { BadRequestException } from "@nestjs/common";
-import { AdType, AdView } from "src/modules/ad/ad-view.entity";
 import type { User } from "src/modules/user/user.entity";
-import { Drawing } from "../drawing.entity";
 import { DrawingAccessService } from "../service/drawing-access.service";
 
 describe("DrawingAccessService", () => {
   const user = { userKey: 1234 } as User;
 
-  const buildService = (drawingCount: number, adViewCount: number) => {
-    const em = {
-      count: jest
-        .fn()
-        .mockResolvedValueOnce(drawingCount)
-        .mockResolvedValueOnce(adViewCount),
+  const buildService = (chanceCount: number) => {
+    const chanceService = {
+      getMyChance: jest.fn().mockResolvedValue({ count: chanceCount }),
     };
 
     return {
-      em,
-      service: new DrawingAccessService(em as never),
+      chanceService,
+      service: new DrawingAccessService(chanceService as never),
     };
   };
 
-  it("오늘 제출 수가 기본 기회와 광고 시청 수의 합보다 적으면 접근을 허용한다", async () => {
-    const { em, service } = buildService(1, 1);
+  it("남은 play chance가 있으면 접근을 허용한다", async () => {
+    const { chanceService, service } = buildService(1);
 
     await expect(service.canAccess(user)).resolves.toBe(true);
 
-    expect(em.count).toHaveBeenNthCalledWith(1, Drawing, {
-      user,
-      createdAt: {
-        $gte: new Date("2026-05-03T15:00:00.000Z"),
-        $lt: new Date("2026-05-04T15:00:00.000Z"),
-      },
-    });
-    expect(em.count).toHaveBeenNthCalledWith(2, AdView, {
-      user,
-      type: AdType.DRAWING,
-      createdAt: {
-        $gte: new Date("2026-05-03T15:00:00.000Z"),
-        $lt: new Date("2026-05-04T15:00:00.000Z"),
-      },
-    });
+    expect(chanceService.getMyChance).toHaveBeenCalledWith(user.userKey);
   });
 
-  it("오늘 제출 수가 허용 기회에 도달하면 접근을 거부한다", async () => {
-    const { service } = buildService(2, 1);
+  it("남은 play chance가 없으면 접근을 거부한다", async () => {
+    const { service } = buildService(0);
 
     await expect(service.canAccess(user)).resolves.toBe(false);
   });
 
   it("접근 권한이 없으면 NO_DRAWING_CHANCE 예외를 던진다", async () => {
-    const { service } = buildService(1, 0);
+    const { service } = buildService(0);
 
     const result = service.validateAccess(user);
 

--- a/server-toss/src/modules/drawing/test/drawing.service.spec.ts
+++ b/server-toss/src/modules/drawing/test/drawing.service.spec.ts
@@ -13,13 +13,6 @@ jest.mock("@davinci/similarity", () => ({
   scoreFinalSimilarity: mockScoreFinalSimilarity,
 }));
 
-jest.mock("src/common/util/time.util", () => ({
-  getSeoulDayRange: () => ({
-    start: new Date("2026-04-26T15:00:00.000Z"),
-    end: new Date("2026-04-27T15:00:00.000Z"),
-  }),
-}));
-
 import type { User } from "../../user/user.entity";
 import { DrawingService } from "../service/drawing.service";
 
@@ -66,10 +59,6 @@ const buildPointService = (granted = false) => ({
   grantDrawingPromotionIfEligible: jest.fn(async () => granted),
 });
 
-const buildDrawingAccessService = () => ({
-  validateAccess: jest.fn(async () => undefined),
-});
-
 const buildUserService = (userKey = 1234) => ({
   getUserInfo: jest.fn(async () => ({ userKey, name: "테스트유저" }) as User),
 });
@@ -88,21 +77,19 @@ const buildService = ({
   userService = buildUserService(),
   promptService = buildPromptService(),
   pointService = buildPointService(),
-  drawingAccessService = buildDrawingAccessService(),
   drawingRepository = buildDrawingRepository(),
   rankingService = buildRankingService(),
 }: {
   userService?: ReturnType<typeof buildUserService>;
   promptService?: ReturnType<typeof buildPromptService>;
   pointService?: ReturnType<typeof buildPointService>;
-  drawingAccessService?: ReturnType<typeof buildDrawingAccessService>;
   drawingRepository?: ReturnType<typeof buildDrawingRepository>;
+  rankingService?: ReturnType<typeof buildRankingService>;
 }) =>
   new DrawingService(
     userService as never,
     promptService as never,
     pointService as never,
-    drawingAccessService as never,
     drawingRepository as never,
     rankingService as never,
   );
@@ -134,13 +121,12 @@ describe("DrawingService", () => {
     });
   });
 
-  describe("드로잉 제출", () => {
+  describe("최종 제출", () => {
     it("유효한 userKey와 strokes를 받으면 drawings를 저장하고 결과를 반환한다", async () => {
       const fakeUser = { userKey: 1234, name: "테스트유저" } as User;
       const userService = {
         getUserInfo: jest.fn(async () => fakeUser),
       };
-      const drawingAccessService = buildDrawingAccessService();
       const drawingRepository = buildDrawingRepository();
       drawingRepository.saveDrawing.mockResolvedValue({
         id: BigInt(42),
@@ -149,7 +135,6 @@ describe("DrawingService", () => {
       const service = buildService({
         userService,
         pointService: buildPointService(false),
-        drawingAccessService,
         drawingRepository,
       });
 
@@ -160,9 +145,6 @@ describe("DrawingService", () => {
       );
 
       expect(userService.getUserInfo).toHaveBeenCalledWith(1234);
-      expect(drawingAccessService.validateAccess).toHaveBeenCalledWith(
-        fakeUser,
-      );
       expect(drawingRepository.saveDrawing).toHaveBeenCalledTimes(1);
       expect(drawingRepository.saveDrawing).toHaveBeenCalledWith(
         fakeUser,
@@ -181,21 +163,6 @@ describe("DrawingService", () => {
         promotionGranted: false,
       });
       expect(result.similarity.score).toBe(87);
-    });
-
-    it("접근 권한 검증에 실패하면 그림을 저장하지 않는다", async () => {
-      const drawingRepository = buildDrawingRepository();
-      const drawingAccessService = {
-        validateAccess: jest.fn(async () => {
-          throw new Error("NO_CHANCE");
-        }),
-      };
-      const service = buildService({ drawingAccessService, drawingRepository });
-
-      await expect(
-        service.submitDrawing(1234, sampleStrokes as never, new Date()),
-      ).rejects.toThrow("NO_CHANCE");
-      expect(drawingRepository.saveDrawing).not.toHaveBeenCalled();
     });
 
     it("프로모션 지급은 PointService에 위임하고 결과를 그대로 반환한다", async () => {
@@ -217,7 +184,7 @@ describe("DrawingService", () => {
     });
   });
 
-  describe("getMyDrawings", () => {
+  describe("내 그림 조회", () => {
     let service: DrawingService;
     let drawingRepository: ReturnType<typeof buildDrawingRepository>;
 
@@ -234,7 +201,6 @@ describe("DrawingService", () => {
       const result = await service.getMyDrawings(1234);
 
       expect(result).toEqual({ userKey: 1234, drawings: [] });
-      expect(drawingRepository.findMyDrawings).toHaveBeenCalledTimes(1);
       expect(drawingRepository.findMyDrawings).toHaveBeenCalledWith(1234);
     });
 
@@ -268,12 +234,11 @@ describe("DrawingService", () => {
           },
         ],
       });
-      expect(drawingRepository.findMyDrawings).toHaveBeenCalledTimes(1);
       expect(drawingRepository.findMyDrawings).toHaveBeenCalledWith(1234);
     });
   });
 
-  describe("getDrawing", () => {
+  describe("그림 상세 조회", () => {
     let service: DrawingService;
     let drawingRepository: ReturnType<typeof buildDrawingRepository>;
 
@@ -292,14 +257,14 @@ describe("DrawingService", () => {
     });
 
     it("그림 상세를 올바른 형식으로 반환한다", async () => {
-      const drawing = makeDrawing(BigInt(1), 78.5, BigInt(10), "홍길동닉");
+      const drawing = makeDrawing(BigInt(1), 78.5, BigInt(10), "랭킹닉");
       drawingRepository.findDrawingById.mockResolvedValueOnce(drawing);
 
       const result = await service.getDrawing(BigInt(1));
 
       expect(result).toMatchObject({
         drawingId: 1,
-        nickname: "홍길동닉",
+        nickname: "랭킹닉",
       });
       expect(result.strokes).toEqual([
         { points: [[0], [0]], color: [255, 0, 0] },

--- a/server-toss/src/modules/play/play.controller.ts
+++ b/server-toss/src/modules/play/play.controller.ts
@@ -1,0 +1,45 @@
+import {
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiConflictResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from "@nestjs/swagger";
+import type { PromptResponse } from "@toss/shared";
+import { getTodayKst } from "src/common/util/today";
+import {
+  CurrentUser,
+  type CurrentUserPayload,
+} from "../auth/decorators/current-user.decorator";
+import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
+import { PlayService } from "./play.service";
+
+@ApiTags("Play")
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller("plays")
+export class PlayController {
+  constructor(private readonly playService: PlayService) {}
+
+  @Post("start")
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: "플레이 시작 및 오늘의 프롬프트 반환" })
+  @ApiOkResponse({
+    description: "기회 1회 소비 후 프롬프트 반환 { promptId, strokes }",
+  })
+  @ApiUnauthorizedResponse({ description: "인증이 필요해요." })
+  @ApiConflictResponse({ description: "그리기 기회가 부족해요." })
+  @ApiNotFoundResponse({ description: "오늘 날짜에 배정된 프롬프트 없음" })
+  start(@CurrentUser() user: CurrentUserPayload): Promise<PromptResponse> {
+    return this.playService.start(user.userKey, getTodayKst());
+  }
+}

--- a/server-toss/src/modules/play/play.module.ts
+++ b/server-toss/src/modules/play/play.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { ChanceModule } from "../chance/chance.module";
+import { PromptModule } from "../prompt/prompt.module";
+import { PlayController } from "./play.controller";
+import { PlayService } from "./play.service";
+
+@Module({
+  imports: [ChanceModule, PromptModule],
+  controllers: [PlayController],
+  providers: [PlayService],
+})
+export class PlayModule {}

--- a/server-toss/src/modules/play/play.service.spec.ts
+++ b/server-toss/src/modules/play/play.service.spec.ts
@@ -1,0 +1,68 @@
+import { NotFoundException } from "@nestjs/common";
+import { PlayService } from "./play.service";
+
+describe("PlayService", () => {
+  const date = new Date("2026-05-12T00:00:00.000Z");
+
+  const buildService = ({
+    promptResult,
+    promptError,
+  }: {
+    promptResult?: unknown;
+    promptError?: Error;
+  }) => {
+    const fork = {};
+    const em = {
+      transactional: jest.fn(async (callback) => callback(fork)),
+    };
+    const chanceService = {
+      consumeWithEntityManager: jest.fn().mockResolvedValue({ count: 0 }),
+    };
+    const promptService = {
+      getPromptByDate: jest.fn(async () => {
+        if (promptError) throw promptError;
+        return promptResult;
+      }),
+    };
+
+    return {
+      fork,
+      em,
+      chanceService,
+      promptService,
+      service: new PlayService(
+        em as never,
+        chanceService as never,
+        promptService as never,
+      ),
+    };
+  };
+
+  it("프롬프트가 있으면 같은 트랜잭션에서 기회를 소비하고 프롬프트를 반환한다", async () => {
+    const prompt = {
+      promptId: 278,
+      strokes: [{ points: [[1], [2]], color: [0, 0, 0] }],
+    };
+    const { fork, chanceService, promptService, service } = buildService({
+      promptResult: prompt,
+    });
+
+    await expect(service.start(760442640, date)).resolves.toEqual(prompt);
+    expect(promptService.getPromptByDate).toHaveBeenCalledWith(date, fork);
+    expect(chanceService.consumeWithEntityManager).toHaveBeenCalledWith(
+      fork,
+      760442640,
+    );
+  });
+
+  it("프롬프트가 없으면 기회를 소비하지 않고 NotFoundException을 던진다", async () => {
+    const { chanceService, service } = buildService({
+      promptError: new NotFoundException("PROMPT_NOT_FOUND"),
+    });
+
+    await expect(service.start(760442640, date)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+    expect(chanceService.consumeWithEntityManager).not.toHaveBeenCalled();
+  });
+});

--- a/server-toss/src/modules/play/play.service.ts
+++ b/server-toss/src/modules/play/play.service.ts
@@ -1,0 +1,22 @@
+import { EntityManager } from "@mikro-orm/core";
+import { Injectable } from "@nestjs/common";
+import type { PromptResponse } from "@toss/shared";
+import { ChanceService } from "../chance/chance.service";
+import { PromptService } from "../prompt/prompt.service";
+
+@Injectable()
+export class PlayService {
+  constructor(
+    private readonly em: EntityManager,
+    private readonly chanceService: ChanceService,
+    private readonly promptService: PromptService,
+  ) {}
+
+  async start(userKey: number, date: Date): Promise<PromptResponse> {
+    return this.em.transactional(async (em) => {
+      const prompt = await this.promptService.getPromptByDate(date, em);
+      await this.chanceService.consumeWithEntityManager(em, userKey);
+      return prompt;
+    });
+  }
+}

--- a/server-toss/src/modules/prompt/prompt.service.ts
+++ b/server-toss/src/modules/prompt/prompt.service.ts
@@ -1,11 +1,11 @@
 import { preprocessStrokes } from "@davinci/similarity";
-import { EntityRepository } from "@mikro-orm/core";
+import { EntityManager, EntityRepository } from "@mikro-orm/core";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { Injectable, Logger, NotFoundException } from "@nestjs/common";
 import type { Stroke } from "@toss/shared";
-import { DailyPrompt } from "./daily-prompt.entity";
 import { DrawingAccessService } from "../drawing/service/drawing-access.service";
 import { UserService } from "../user/user.service";
+import { DailyPrompt } from "./daily-prompt.entity";
 
 type Preprocessed = ReturnType<typeof preprocessStrokes>;
 
@@ -31,11 +31,19 @@ export class PromptService {
 
   async getPromptByDate(
     date: Date,
+    em?: EntityManager,
   ): Promise<{ promptId: number; strokes: Stroke[] }> {
-    const daily = await this.dailyRepo.findOne(
-      { promptDate: date },
-      { populate: ["prompt"] }, // prompt 관계까지 JOIN으로 함께 로드 (기본 lazy)
-    );
+    const daily = em
+      ? await em.findOne(
+          DailyPrompt,
+          { promptDate: date },
+          { populate: ["prompt"] },
+        )
+      : await this.dailyRepo.findOne(
+          { promptDate: date },
+          { populate: ["prompt"] },
+        );
+
     if (!daily) {
       this.logger.warn(
         { event: "prompt.not_found", date: date.toISOString() },
@@ -43,6 +51,7 @@ export class PromptService {
       );
       throw new NotFoundException("PROMPT_NOT_FOUND");
     }
+
     const prompt = daily.prompt;
     return {
       promptId: Number(prompt.id),
@@ -62,6 +71,7 @@ export class PromptService {
       );
       return { promptId, preprocessed: preprocessStrokes(strokes) };
     }
+
     const cached = this.preprocessedCache.get(promptId);
     if (cached) {
       this.logger.debug(
@@ -70,6 +80,7 @@ export class PromptService {
       );
       return { promptId, preprocessed: cached };
     }
+
     const preprocessed = preprocessStrokes(strokes);
     this.preprocessedCache.set(promptId, preprocessed);
     this.logger.debug(


### PR DESCRIPTION
## 개요

클라이언트에서 표시되는 남은 도전 기회와 서버의 실제 도전 가능 여부가 서로 다른 기준으로 계산되던 문제를 수정했습니다.

기존에는 클라이언트가 play_chances.count를 기준으로 “광고 없이 N번 도전”을 표시했지만, /prompt 및 /drawing 서버 검증은 drawings + ad_views 기준을 사용해 일부 사용자에게 NO_DRAWING_CHANCE 오류가 발생했습니다.

게임 시작 흐름을 POST /plays/start로 통합해, 기회 차감과 프롬프트 조회를 하나의 트랜잭션에서 처리하도록 변경했습니다.

## 관련 이슈

Closes #366 

## 변경 사항

- `DrawingAccessService`의 기회 판단 기준을 `play_chances` 기반으로 정리
- `POST /plays/start` API 추가
  - 오늘의 프롬프트 조회
  - 도전 기회 1회 차감
  - 프롬프트 응답 반환
  - 위 과정을 하나의 트랜잭션에서 처리
- 클라이언트의 기존 `startPlay()` + `getPrompt()` 분리 호출을 `startPlay()` 단일 흐름으로 변경
- `/plays/start` 실패 시 로컬 play session 정리
- 최종 그림 등록(`/drawing`) 시 남은 기회를 다시 검증하지 않도록 수정
- `PromptService.getPromptByDate()`를 `PlayService`에서도 재사용할 수 있도록 optional `EntityManager` 인자 추가
- `PlayModule` 추가
- 관련 서버/클라이언트 테스트 갱신

### 체크리스트

<!-- 리뷰 전에 본인이 확인해야 하는 항목 -->

- [ ] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [ ] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [ ] 주석/변수명 등 가독성을 고려했습니다.
- [ ] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [ ] API, DB 변경 시 문서화했습니다.
- [ ] 새로운 의존성 추가 시 팀과 공유했습니다.

## 테스트 및 검증 내용

- 로컬 수동 검증
  - `play_chances.count = 1` 상태에서 “광고 없이 1번 도전” 클릭 시 정상적으로 프롬프트 진입 확인
  - 플레이 시작 후 `count = 0` 상태에서도 최종 그림 등록 성공 확인
  - 기존에 발생하던 `/prompt` 및 `/drawing`의 `NO_DRAWING_CHANCE` 오류가 재현되지 않음을 확인

## AI 활용 점검

- 운영 서버 로그 기반 원인 분석
- 클라이언트와 서버의 게임 기회 기준 불일치 지점 추적
- 변경 범위 및 테스트 시나리오 점검  

## 추가 참고 사항

> 리뷰어가 알아야 할 특이사항, 주의사항 등을 적어주세요.

## 스크린샷 / UI 변경 (선택)

> UI가 변경된 경우 스크린샷을 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 게임 시작 API 추가로 즉시 프롬프트를 받아와 바로 플레이로 이동하도록 개선

* **Refactor**
  * 게임 시작/다시하기 흐름이 프롬프트를 직접 반환하도록 재구성되어 네비게이션이 간소화됨
  * 그리기 권한 판정 로직을 기회 기반으로 단순화

* **Bug Fixes**
  * 프롬프트 부족 시 동일한 “그리기 기회가 부족해요.” 토스트를 일관되게 표시

* **Tests**
  * 플레이·재시도 관련 테스트를 새 흐름에 맞게 업데이트

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boostcampwm2025/web04-we-are-all-da-Vinci/pull/367)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->