### PR TITLE
[feat] 공유 링크 OG 이미지 적용

### DIFF
--- a/client-toss/src/App.tsx
+++ b/client-toss/src/App.tsx
@@ -3,10 +3,13 @@ import { initTossAdsOnce } from "@/shared/lib";
 import { TDSMobileAITProvider } from "@toss/tds-mobile-ait";
 import { useEffect } from "react";
 import { RouterProvider } from "react-router-dom";
+import { useShareButton } from "./feature/shareLink";
 const App = () => {
   useEffect(() => {
     initTossAdsOnce().catch(console.warn);
   }, []);
+
+  useShareButton();
 
   return (
     <TDSMobileAITProvider>

--- a/client-toss/src/feature/shareLink/hooks/useShareButton.ts
+++ b/client-toss/src/feature/shareLink/hooks/useShareButton.ts
@@ -1,0 +1,44 @@
+import {
+  getTossShareLink,
+  partner,
+  share,
+  tdsEvent,
+} from "@apps-in-toss/web-framework";
+import { useEffect } from "react";
+
+const handleShare = async () => {
+  const tossLink = await getTossShareLink(
+    "intoss://we-are-all-da-vinci",
+    "https://imgur.com/JUlHwsT.png",
+  );
+
+  await share({ message: tossLink });
+};
+
+const useShareButton = () => {
+  useEffect(() => {
+    partner.addAccessoryButton({
+      id: "share",
+      title: "공유",
+      icon: {
+        name: "icon-share-dots-thin-mono",
+      },
+    });
+
+    const cleanup = tdsEvent.addEventListener("navigationAccessoryEvent", {
+      onEvent: async ({ id }) => {
+        if (id === "share") {
+          try {
+            await handleShare();
+          } catch (error) {
+            console.error(error);
+          }
+        }
+      },
+    });
+
+    return cleanup;
+  }, []);
+};
+
+export default useShareButton;

--- a/client-toss/src/feature/shareLink/index.ts
+++ b/client-toss/src/feature/shareLink/index.ts
@@ -1,0 +1,1 @@
+export { default as useShareButton } from "./hooks/useShareButton";


### PR DESCRIPTION
## 개요

미니앱 공유 시 OG 이미지가 적용되도록 구현하였습니다.

단 기본 내비게이션바 더보기(... 버튼)에서 제공하는 공유하기 기능은 직접 수정할 수 없어, 내비게이션 바에 공유용 액세서리 버튼을 추가하고 해당 기능을 이용 시 OG 이미지가 적용되도록 했습니다.

## 관련 이슈

Closes #368 

## 변경 사항

### 체크리스트

<!-- 리뷰 전에 본인이 확인해야 하는 항목 -->

- [ ] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [ ] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [ ] 주석/변수명 등 가독성을 고려했습니다.
- [ ] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [ ] API, DB 변경 시 문서화했습니다.
- [ ] 새로운 의존성 추가 시 팀과 공유했습니다.

## 테스트 및 검증 내용

내비게이션 바에 커스텀 공유 버튼 추가

<img width="756" height="1487" alt="image" src="https://github.com/user-attachments/assets/6758dca2-bb91-4185-8f65-59cf6e2cbbfc" />

첫번째는 커스텀 공유 버튼을 사용한 공유, 두번째는 내비게이션바의 기본 공유 기능을 사용한 공유 시 모습입니다. OG이미지 적용 문서에 따르면 getShareLink()라는 앱인토스 제공 함수를 써서 OG이미지를 적용하는데, 기본 제공 공유 기능은 직접 수정할 수 있는 방법을 찾지 못해 OG이미지를 적용하지 못했습니다.

<img width="1080" height="1507" alt="image" src="https://github.com/user-attachments/assets/d9f2bcc5-993e-4fd5-82b5-eebbb8bb1128" />


## AI 활용 점검

> AI를 어떻게 활용했는지 적어주세요.

## 추가 참고 사항

> 리뷰어가 알아야 할 특이사항, 주의사항 등을 적어주세요.

## 스크린샷 / UI 변경 (선택)

> UI가 변경된 경우 스크린샷을 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 공유 기능 추가: 애플리케이션에 공유 버튼이 추가되었습니다. 사용자는 공유 버튼을 통해 앱의 링크를 다양한 채널에서 쉽게 공유할 수 있습니다. 공유 시 서비스 제공자의 공유 링크가 포함됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boostcampwm2025/web04-we-are-all-da-Vinci/pull/369)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->