### PR TITLE
[feat] 인트로 화면 도입과 공유 메시지·노랑 팔레트 개선

### DIFF
--- a/client-toss/src/App.tsx
+++ b/client-toss/src/App.tsx
@@ -1,10 +1,14 @@
 import { router } from "@/app/config/router";
 import { initTossAdsOnce } from "@/shared/lib";
+import { IntroView } from "@/views/intro";
 import { TDSMobileAITProvider } from "@toss/tds-mobile-ait";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { RouterProvider } from "react-router-dom";
 import { useShareButton } from "./feature/shareLink";
+
 const App = () => {
+  const [hasStarted, setHasStarted] = useState(false);
+
   useEffect(() => {
     initTossAdsOnce().catch(console.warn);
   }, []);
@@ -13,7 +17,11 @@ const App = () => {
 
   return (
     <TDSMobileAITProvider>
-      <RouterProvider router={router} />
+      {hasStarted ? (
+        <RouterProvider router={router} />
+      ) : (
+        <IntroView onStart={() => setHasStarted(true)} />
+      )}
     </TDSMobileAITProvider>
   );
 };

--- a/client-toss/src/App.tsx
+++ b/client-toss/src/App.tsx
@@ -6,8 +6,12 @@ import { useEffect, useState } from "react";
 import { RouterProvider } from "react-router-dom";
 import { useShareButton } from "./feature/shareLink";
 
+const INTRO_SEEN_KEY = "introSeen";
+
 const App = () => {
-  const [hasStarted, setHasStarted] = useState(false);
+  const [hasStarted, setHasStarted] = useState(
+    () => sessionStorage.getItem(INTRO_SEEN_KEY) === "1",
+  );
 
   useEffect(() => {
     initTossAdsOnce().catch(console.warn);
@@ -15,12 +19,17 @@ const App = () => {
 
   useShareButton();
 
+  const handleStart = () => {
+    sessionStorage.setItem(INTRO_SEEN_KEY, "1");
+    setHasStarted(true);
+  };
+
   return (
     <TDSMobileAITProvider>
       {hasStarted ? (
         <RouterProvider router={router} />
       ) : (
-        <IntroView onStart={() => setHasStarted(true)} />
+        <IntroView onStart={handleStart} />
       )}
     </TDSMobileAITProvider>
   );

--- a/client-toss/src/feature/drawing/config/colors.ts
+++ b/client-toss/src/feature/drawing/config/colors.ts
@@ -22,8 +22,8 @@ export const PALETTE_COLORS = [
   },
   {
     name: "노랑",
-    hex: "#EAB308",
-    rgb: [234, 179, 8] as const,
-    ring: "ring-yellow-500",
+    hex: "#FACC15",
+    rgb: [250, 204, 21] as const,
+    ring: "ring-yellow-400",
   },
 ] as const;

--- a/client-toss/src/feature/shareLink/config/shareMessage.ts
+++ b/client-toss/src/feature/shareLink/config/shareMessage.ts
@@ -1,0 +1,8 @@
+const buildShareMessageWithRanking = (
+  score: number,
+  rank: number,
+  tossLink: string,
+): string =>
+  `제 다빈치 점수는 ${score}점이에요! (랭킹 ${rank}위)\n같이 도전해봐요\n${tossLink}`;
+
+export { buildShareMessageWithRanking };

--- a/client-toss/src/feature/shareLink/hooks/useShareButton.ts
+++ b/client-toss/src/feature/shareLink/hooks/useShareButton.ts
@@ -7,6 +7,7 @@ import {
 import { useEffect } from "react";
 import { serverTossApi } from "@/shared/api";
 import type { MyRankingResponse } from "@/entities/ranking";
+import { buildShareMessageWithRanking } from "../config/shareMessage";
 
 const buildShareMessage = (
   tossLink: string,
@@ -14,7 +15,7 @@ const buildShareMessage = (
 ): string => {
   if (myRanking?.state === "FOUND") {
     const { score, rank } = myRanking.ranking;
-    return `제 다빈치 점수는 ${score}점이에요! (랭킹 ${rank}위)\n같이 도전해봐요\n${tossLink}`;
+    return buildShareMessageWithRanking(score, rank, tossLink);
   }
   return tossLink;
 };

--- a/client-toss/src/feature/shareLink/hooks/useShareButton.ts
+++ b/client-toss/src/feature/shareLink/hooks/useShareButton.ts
@@ -5,14 +5,34 @@ import {
   tdsEvent,
 } from "@apps-in-toss/web-framework";
 import { useEffect } from "react";
+import { serverTossApi } from "@/shared/api";
+import type { MyRankingResponse } from "@/entities/ranking";
+
+const buildShareMessage = (
+  tossLink: string,
+  myRanking: MyRankingResponse | null,
+): string => {
+  if (myRanking?.state === "FOUND") {
+    const { score, rank } = myRanking.ranking;
+    return `제 다빈치 점수는 ${score}점이에요! (랭킹 ${rank}위)\n같이 도전해봐요\n${tossLink}`;
+  }
+  return tossLink;
+};
 
 const handleShare = async () => {
+  let myRanking: MyRankingResponse | null = null;
+  try {
+    myRanking = await serverTossApi.getMyRanking();
+  } catch {
+    // 점수 조회 실패해도 링크는 공유되도록 폴백
+  }
+
   const tossLink = await getTossShareLink(
     "intoss://we-are-all-da-vinci",
     "https://imgur.com/JUlHwsT.png",
   );
 
-  await share({ message: tossLink });
+  await share({ message: buildShareMessage(tossLink, myRanking) });
 };
 
 const useShareButton = () => {

--- a/client-toss/src/index.css
+++ b/client-toss/src/index.css
@@ -12,7 +12,7 @@
     --color-red: #ef4444;
     --color-blue: #3b82f6;
     --color-green: #22c55e;
-    --color-yellow: #eab308;
+    --color-yellow: #facc15;
 
     /* brand */
     --color-toss-blue: #0166fe;

--- a/client-toss/src/views/intro/config/steps.ts
+++ b/client-toss/src/views/intro/config/steps.ts
@@ -1,0 +1,22 @@
+import { brainImg, painterMan1Img, paletteImg } from "@/shared/assets/images";
+
+export const STEPS = [
+  {
+    icon: brainImg,
+    alt: "뇌 아이콘",
+    title: "다빈치처럼 똑똑하게 외워요",
+    description: "잠시 후 똑같이 그려야 해요",
+  },
+  {
+    icon: painterMan1Img,
+    alt: "화가 아이콘",
+    title: "다빈치처럼 멋지게 그려봐요",
+    description: "기억을 떠올려 캔버스에 그려요",
+  },
+  {
+    icon: paletteImg,
+    alt: "팔레트 아이콘",
+    title: "어떻게 그렸는지 확인해요",
+    description: "원본과 닮을수록 높은 점수예요",
+  },
+];

--- a/client-toss/src/views/intro/index.ts
+++ b/client-toss/src/views/intro/index.ts
@@ -1,0 +1,1 @@
+export { default as IntroView } from "./ui/IntroView";

--- a/client-toss/src/views/intro/ui/IntroView.tsx
+++ b/client-toss/src/views/intro/ui/IntroView.tsx
@@ -1,0 +1,83 @@
+import { painterMan2Img } from "@/shared/assets/images";
+import { Button, Paragraph, Top } from "@toss/tds-mobile";
+import { STEPS } from "../config/steps";
+
+type IntroViewProps = {
+  onStart: () => void;
+};
+
+const IntroView = ({ onStart }: IntroViewProps) => {
+  return (
+    <div data-no-safe-area-bottom className="flex h-full flex-col">
+      <div className="flex flex-1 flex-col py-2">
+        <Top
+          upperGap={12}
+          lowerGap={0}
+          title={
+            <Top.TitleParagraph size={28}>
+              그림을 외워서
+              <br />
+              똑같이 그려봐요
+            </Top.TitleParagraph>
+          }
+          subtitleBottom={
+            <Top.SubtitleParagraph size={17}>
+              <Top.SubtitleParagraph.Text>
+                기억하고 그리며 두뇌를 깨우는{" "}
+              </Top.SubtitleParagraph.Text>
+              <Top.SubtitleParagraph.Text
+                fontWeight="bold"
+                color="var(--color-toss-blue)"
+              >
+                우리 모두 다빈치
+              </Top.SubtitleParagraph.Text>
+            </Top.SubtitleParagraph>
+          }
+        />
+
+        <div className="flex flex-1 items-center justify-center">
+          <img
+            src={painterMan2Img}
+            alt="우리 모두 다빈치 마스코트"
+            className="h-44 w-44 shrink-0 object-contain"
+          />
+        </div>
+
+        <div className="flex flex-col gap-2 px-(--page-px)">
+          {STEPS.map((step) => (
+            <div
+              key={step.title}
+              className="flex items-center gap-3 rounded-xl bg-gray-100 px-3.5 py-2.5"
+            >
+              <img
+                src={step.icon}
+                alt={step.alt}
+                className="size-8 shrink-0 object-contain"
+              />
+              <div className="flex flex-col gap-0.5">
+                <Paragraph.Text
+                  typography="t5"
+                  fontWeight="bold"
+                  color="rgba(0,12,30,0.88)"
+                >
+                  {step.title}
+                </Paragraph.Text>
+                <Paragraph.Text typography="t6" color="rgba(0,19,43,0.58)">
+                  {step.description}
+                </Paragraph.Text>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <section className="shrink-0 px-(--page-px) pt-3 pb-[env(safe-area-inset-bottom)]">
+        <Button color="primary" display="block" onClick={onStart}>
+          시작하기
+        </Button>
+      </section>
+    </div>
+  );
+};
+
+export default IntroView;

--- a/client-toss/src/views/intro/ui/IntroView.tsx
+++ b/client-toss/src/views/intro/ui/IntroView.tsx
@@ -1,5 +1,6 @@
 import { painterMan2Img } from "@/shared/assets/images";
-import { Button, Paragraph, Top } from "@toss/tds-mobile";
+import { useExitGuard } from "@/shared/lib";
+import { Button, ConfirmDialog, Paragraph, Top } from "@toss/tds-mobile";
 import { STEPS } from "../config/steps";
 
 type IntroViewProps = {
@@ -7,6 +8,8 @@ type IntroViewProps = {
 };
 
 const IntroView = ({ onStart }: IntroViewProps) => {
+  const { showDialog, setShowDialog, exit } = useExitGuard();
+
   return (
     <div data-no-safe-area-bottom className="flex h-full flex-col">
       <div className="flex flex-1 flex-col py-2">
@@ -76,6 +79,23 @@ const IntroView = ({ onStart }: IntroViewProps) => {
           시작하기
         </Button>
       </section>
+
+      <ConfirmDialog
+        open={showDialog}
+        onClose={() => setShowDialog(false)}
+        title="앱을 종료할까요?"
+        description="언제든 다시 들어와서 시작할 수 있어요"
+        confirmButton={
+          <ConfirmDialog.ConfirmButton onClick={exit}>
+            종료
+          </ConfirmDialog.ConfirmButton>
+        }
+        cancelButton={
+          <ConfirmDialog.CancelButton onClick={() => setShowDialog(false)}>
+            계속 보기
+          </ConfirmDialog.CancelButton>
+        }
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- 첫 진입 시 IntroView를 1회 노출하고 onStart 후 라우터로 전환
- 공유 메시지에 `/rankings/me` 점수·랭킹을 포함 (조회 실패 시 링크만 폴백)
- 드로잉 노랑 팔레트 `#EAB308` → `#FACC15`로 변경해 프롬프트 데이터 톤과 일치

Closes #363

## Test plan

- [ ] 토스 샌드박스 첫 진입 시 IntroView 노출, 시작 후 대시보드로 이동
- [ ] 공유 버튼 → 메시지에 점수·랭킹 텍스트 포함
- [ ] 메모라이즈 노랑 vs 그리기 팔레트·획 노랑 색이 일치
- [ ] `pnpm test`, `pnpm qa:ci` 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 앱 시작 시 인트로 화면이 표시됩니다.
* 공유 메시지에 사용자 순위가 포함됩니다.

## 스타일

* 색상 팔레트의 노랑색 값이 업데이트되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boostcampwm2025/web04-we-are-all-da-Vinci/pull/373)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->