### PR TITLE
[design] 배너 광고 상하 여백 제거

### DIFF
--- a/client-toss/src/entities/myScoreCard/ui/MyScoreCard.tsx
+++ b/client-toss/src/entities/myScoreCard/ui/MyScoreCard.tsx
@@ -59,10 +59,7 @@ const MyScoreCard = ({
       )}
       {!hideAd && (
         <div className="w-full px-(--card-mx)">
-          <BannerAd
-            adGroupId={AD_GROUP_IDS.BANNER_LIST}
-            className="mt-px mb-2 w-full"
-          />
+          <BannerAd adGroupId={AD_GROUP_IDS.BANNER_LIST} className="w-full" />
         </div>
       )}
       {isDetailOpen && (

--- a/client-toss/src/entities/ranking/ui/RankingList.tsx
+++ b/client-toss/src/entities/ranking/ui/RankingList.tsx
@@ -33,7 +33,7 @@ const RankingList = () => {
         return [
           entry,
           <div key={`ad-${idx}`} className="px-(--card-mx)">
-            <BannerAd adGroupId={AD_GROUP_IDS.BANNER_LIST} className="my-1" />
+            <BannerAd adGroupId={AD_GROUP_IDS.BANNER_LIST} />
           </div>,
         ];
       })}

--- a/client-toss/src/shared/ui/bannerAd/BannerAd.tsx
+++ b/client-toss/src/shared/ui/bannerAd/BannerAd.tsx
@@ -13,7 +13,7 @@ interface BannerAdProps {
 
 const BANNER_HEIGHTS: Record<BannerType, number> = {
   list: 96,
-  feed: 410,
+  feed: 350,
 };
 
 const MockBanner = ({
@@ -29,7 +29,6 @@ const MockBanner = ({
       style={{ height }}
       className={clsx(
         "flex w-full items-center justify-center rounded-2xl bg-gray-100 text-sm text-(--color-grey)",
-        type === "feed" && "mt-2",
         className,
       )}
     >
@@ -90,7 +89,7 @@ const BannerAd = ({ adGroupId, type = "list", className }: BannerAdProps) => {
   return (
     <div
       ref={bannerRef}
-      style={{ width: "100%", height }}
+      style={type === "feed" ? { width: "100%" } : { width: "100%", height }}
       className={className}
     />
   );

--- a/client-toss/src/views/ranking/ui/RankingView.tsx
+++ b/client-toss/src/views/ranking/ui/RankingView.tsx
@@ -7,26 +7,28 @@ import { Border, ListHeader } from "@toss/tds-mobile";
 const RankingView = () => {
   return (
     <div className="pt-4 pb-2">
-      <div className="flex w-full flex-col items-center gap-4 px-(--page-px) pb-4">
+      <div className="flex w-full flex-col items-center gap-4 px-(--page-px) pb-2">
         <Podium />
       </div>
       <Border variant="full" />
       <div className="px-(--card-mx)">
-        <BannerAd adGroupId={AD_GROUP_IDS.BANNER_LIST} className="mt-2 mb-2" />
+        <BannerAd adGroupId={AD_GROUP_IDS.BANNER_LIST} />
       </div>
-      <ListHeader
-        title={
-          <ListHeader.TitleParagraph typography="t5" fontWeight="bold">
-            TOP 100
-          </ListHeader.TitleParagraph>
-        }
-        description={
-          <ListHeader.DescriptionParagraph>
-            눌러서 상세 정보를 볼 수 있어요
-          </ListHeader.DescriptionParagraph>
-        }
-        descriptionPosition="bottom"
-      />
+      <div className="-mt-4">
+        <ListHeader
+          title={
+            <ListHeader.TitleParagraph typography="t5" fontWeight="bold">
+              TOP 100
+            </ListHeader.TitleParagraph>
+          }
+          description={
+            <ListHeader.DescriptionParagraph>
+              눌러서 상세 정보를 볼 수 있어요
+            </ListHeader.DescriptionParagraph>
+          }
+          descriptionPosition="bottom"
+        />
+      </div>
       <RankingList />
     </div>
   );

--- a/client-toss/src/views/rankingDetail/ui/RankingDetailView.tsx
+++ b/client-toss/src/views/rankingDetail/ui/RankingDetailView.tsx
@@ -25,13 +25,8 @@ const RankingDetailView = () => {
       return (
         <>
           <MyScoreCard drawing={drawing} hideHeader hideAd />
-          <div className="mt-3">
-            <Score
-              value={Number(drawing.similarity.score.toFixed(2))}
-              size="s"
-            />
-          </div>
-          <div className="mt-3 px-(--card-mx)">
+          <Score value={Number(drawing.similarity.score.toFixed(2))} size="s" />
+          <div className="px-(--card-mx)">
             <BannerAd type="feed" adGroupId={AD_GROUP_IDS.BANNER_FEED} />
           </div>
         </>
@@ -76,7 +71,7 @@ const RankingDetailView = () => {
 
       {renderBody()}
 
-      <div className="mt-8 px-(--page-px)">
+      <div className="mt-3 px-(--page-px)">
         <Link to="/ranking">
           <Button size="xlarge" variant="weak" display="block">
             랭킹으로 돌아가기


### PR DESCRIPTION
## 개요

배너 광고(리스트/피드) 주변의 자잘한 상하 여백을 제거해 Viewable(50%+1초) 노출 면적을 확보합니다. 또한 토스 광고 SDK 문서 가이드대로 피드형 컨테이너 높이는 SDK 자동 결정에 맡깁니다.

## 관련 이슈

- Closes #380

## 변경 사항

### 체크리스트

- [x] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [x] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [x] 주석/변수명 등 가독성을 고려했습니다.
- [x] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [x] API, DB 변경 시 문서화했습니다. (해당 없음)
- [x] 새로운 의존성 추가 시 팀과 공유했습니다. (해당 없음)

주요 변경:
- `BannerAd`: 피드형 실제 컨테이너 `height` 미지정으로 변경 (토스 문서 권장), MockBanner placeholder 410→350
- `RankingView`: 광고 className 정리 + ListHeader 위 음수 마진으로 광고와 간격 좁힘, Podium-Border 사이는 살짝만 유지
- `RankingList`: 10번째마다 끼는 광고 `my-1` 제거
- `MyScoreCard`: 광고 상하 마진 제거 (`w-full`만 유지)
- `RankingDetailView`: 광고 wrapper `mt-3` 제거, Score wrapper div 제거, CTA 버튼 wrapper `mt-8 → mt-3`

## 테스트 및 검증 내용

- `pnpm --filter client-toss test` 18 files / 121 tests 통과
- `pnpm --filter client-toss qa:ci` 8/8 PASS (광고 SDK 통합·번들 사이즈 포함)
- 토스 샌드박스에서 Ranking / RankingDetail / Memorize / Submitted / MyScoreCard 5개 위치 시각 확인

## AI 활용 점검

Claude Code로 변경 위치 탐색, 토스 광고 SDK 문서 검색(MCP), 코드 수정 보조에 활용했습니다.

## 추가 참고 사항

- 피드형 광고는 토스 문서가 `width: 100% + height 미지정`을 권장하며, height를 강제하면 광고 비율보다 클 때 빈 공간이 남는 문제가 있어 SDK 자동 결정으로 전환했습니다.
- 리스트형은 문서 권장값(96px) 그대로 유지했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 광고 배너의 크기와 간격을 조정하여 더 나은 화면 구성을 제공합니다.
  
* **Refactor**
  * 랭킹 뷰 및 상세 정보 뷰의 레이아웃 간격을 최적화했습니다.
  * 광고 배너 렌더링 방식을 개선하여 일관된 표시를 보장합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boostcampwm2025/web04-we-are-all-da-Vinci/pull/382)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->