### PR TITLE
[fix] 일일 첫 자동 플레이 기회 차감 오류 수정

### DIFF
--- a/client-toss/src/views/dashboard/ui/DashboardView.tsx
+++ b/client-toss/src/views/dashboard/ui/DashboardView.tsx
@@ -27,6 +27,7 @@ const DashboardView = () => {
   const [toastOpen, setToastOpen] = useState(false);
   const [toastText, setToastText] = useState("일시적 오류가 발생했어요");
   const anonymousHashRef = useRef<string>("local");
+  const autoStartedRef = useRef(false);
   const { myDrawings, isLoading, refetch: refetchDrawings } = useMyDrawings();
   const {
     chanceCount,
@@ -75,6 +76,12 @@ const DashboardView = () => {
         return;
       }
 
+      // 게임 시작 시점에 자동시작 게이트를 닫는다 — 제출 없이 이탈해도 재자동시작/이중차감 방지
+      localStorage.setItem(
+        `lastPlayed_${anonymousHashRef.current}`,
+        formatLocalDate(),
+      );
+
       navigate("/memorize", {
         state: {
           promptId: prompt.promptId,
@@ -102,7 +109,6 @@ const DashboardView = () => {
         // state를 즉시 제거하여 재마운트 시 토스트 재표시 방지
         window.history.replaceState({}, "");
 
-        localStorage.setItem(`lastPlayed_${hash}`, formatLocalDate());
         refetchDrawings();
 
         const promotionGranted = (
@@ -126,6 +132,13 @@ const DashboardView = () => {
         setInitialLoading(false);
         return;
       }
+
+      // effect가 두 번 실행돼도 자동시작은 마운트당 1회만 — startPlay 이중 호출 방지
+      if (autoStartedRef.current) {
+        setInitialLoading(false);
+        return;
+      }
+      autoStartedRef.current = true;
 
       // 첫 방문: initialLoading=true 상태로 게임 시작 (로딩 화면 유지)
       try {
@@ -156,6 +169,11 @@ const DashboardView = () => {
         setToastOpen(true);
         return;
       }
+
+      localStorage.setItem(
+        `lastPlayed_${anonymousHashRef.current}`,
+        formatLocalDate(),
+      );
 
       navigate("/memorize", {
         state: {

--- a/server-toss/package.json
+++ b/server-toss/package.json
@@ -26,6 +26,7 @@
     "seed:drawing:small:fresh": "npx mikro-orm migration:fresh --seed SmallUserDrawingSeeder",
     "seed:drawing:large": "npx mikro-orm seeder:run --class=LargeUserDrawingSeeder",
     "seed:ranking": "npx mikro-orm seeder:run --class=RankingSeeder",
+    "chance:reset": "bash scripts/reset-chance.sh",
     "migration:check": "mikro-orm migration:check",
     "migration:list": "mikro-orm migration:list",
     "migration:up": "mikro-orm migration:up",

--- a/server-toss/scripts/reset-chance.sh
+++ b/server-toss/scripts/reset-chance.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# 샌드박스에서 "당일 첫 플레이" 상태를 모의 구성하는 리셋 스크립트.
+# play_chances.last_reset_at을 과거로 돌려 오늘 무료 플레이가 가능한 상태로 만든다.
+# (클라이언트 localStorage는 WebView 내부라 직접 못 건드리므로 안내만 출력한다.)
+set -euo pipefail
+
+MYSQL_CONTAINER="${MYSQL_CONTAINER:-daVinci-mysql}"
+MYSQL_DATABASE="${MYSQL_DATABASE:-daVinci_toss}"
+PAST_DATE="2000-01-01 00:00:00"
+
+mysql_exec() {
+  docker exec -i "$MYSQL_CONTAINER" mysql -uroot "$MYSQL_DATABASE" "$@"
+}
+
+if ! docker ps --format '{{.Names}}' | grep -qx "$MYSQL_CONTAINER"; then
+  echo "❌ MySQL 컨테이너 '$MYSQL_CONTAINER'가 실행 중이 아니에요."
+  echo "   먼저 실행하세요: pnpm infra:mysql:up"
+  exit 1
+fi
+
+# pnpm은 `pnpm chance:reset -- 3` 형태에서 `--`를 스크립트로 그대로 넘기므로 제거한다.
+if [[ "${1:-}" == "--" ]]; then shift; fi
+
+USER_KEY="${1:-}"
+CHARGED_COUNT="${2:-0}"
+
+if [[ -z "$USER_KEY" ]]; then
+  echo "최근 유저 10명:"
+  mysql_exec -e "SELECT * FROM users ORDER BY user_key DESC LIMIT 10;"
+  echo
+  echo "사용법: pnpm chance:reset -- <user_key> [charged_count]"
+  echo "  예) pnpm chance:reset -- 3      # user_key=3, 충전분 0으로 리셋"
+  echo "  예) pnpm chance:reset -- 3 4    # user_key=3, 충전분 4로 리셋 (이월 시나리오)"
+  exit 0
+fi
+
+if ! [[ "$USER_KEY" =~ ^[0-9]+$ ]]; then
+  echo "❌ user_key는 숫자여야 해요: '$USER_KEY'"
+  exit 1
+fi
+if ! [[ "$CHARGED_COUNT" =~ ^[0-9]+$ ]]; then
+  echo "❌ charged_count는 숫자여야 해요: '$CHARGED_COUNT'"
+  exit 1
+fi
+
+USER_EXISTS=$(mysql_exec -N -s -e "SELECT COUNT(*) FROM users WHERE user_key = $USER_KEY;")
+if [[ "$USER_EXISTS" -eq 0 ]]; then
+  echo "❌ user_key=$USER_KEY 인 유저가 없어요."
+  echo "   인자 없이 실행하면 유저 목록을 볼 수 있어요: pnpm chance:reset"
+  exit 1
+fi
+
+echo "── 리셋 전 play_chances (user_key=$USER_KEY) ──"
+mysql_exec -e "SELECT * FROM play_chances WHERE user_key = $USER_KEY;"
+
+mysql_exec -e "INSERT INTO play_chances (user_key, \`count\`, last_reset_at)
+VALUES ($USER_KEY, $CHARGED_COUNT, '$PAST_DATE')
+ON DUPLICATE KEY UPDATE \`count\` = $CHARGED_COUNT, last_reset_at = '$PAST_DATE';"
+
+echo "── 리셋 후 play_chances ──"
+mysql_exec -e "SELECT * FROM play_chances WHERE user_key = $USER_KEY;"
+
+cat <<'GUIDE'
+
+✅ 서버 리셋 완료 — 오늘 무료 플레이가 가능한 상태예요.
+
+다음으로 클라이언트 localStorage도 정리해야 자동 시작이 발동해요.
+샌드박스 WebView 웹 인스펙터(콘솔)에 아래 한 줄을 붙여넣고 미니앱을 새로고침하세요:
+
+  Object.keys(localStorage).filter(k=>k.startsWith('lastPlayed')).forEach(k=>localStorage.removeItem(k))
+GUIDE

--- a/server-toss/src/modules/chance/chance.service.spec.ts
+++ b/server-toss/src/modules/chance/chance.service.spec.ts
@@ -20,23 +20,26 @@ import { ChanceService } from "./chance.service";
 import { PlayChance } from "./play-chance.entity";
 import { ShareLog } from "./share-log.entity";
 
+// TODAY_START = KST 2026-05-09 00:00 (= UTC 2026-05-08 15:00). getSeoulDayRange()의 start와 일치.
 const TODAY_START = new Date("2026-05-08T15:00:00.000Z");
+// YESTERDAY_START = KST 2026-05-08 00:00. lastResetAt이 이 값이면 오늘 무료 플레이 가능.
 const YESTERDAY_START = new Date("2026-05-07T15:00:00.000Z");
 const ALLOWED_AD_GROUP = "ait.dev.allowed-group";
 const ALLOWED_MODULE = "module-allowed";
 
-interface ForkApi {
+interface EmApi {
   findOne: jest.Mock;
   count: jest.Mock;
   create: jest.Mock;
   persist: jest.Mock;
   getReference: jest.Mock;
   flush: jest.Mock;
+  transactional: jest.Mock;
 }
 
 const buildEm = (existing: PlayChance | null, todayShareLogs = 0) => {
   const persisted: unknown[] = [];
-  const fork: ForkApi = {
+  const em: EmApi = {
     findOne: jest.fn(async () => existing),
     count: jest.fn(async (entity) =>
       entity === ShareLog ? todayShareLogs : 0,
@@ -57,16 +60,11 @@ const buildEm = (existing: PlayChance | null, todayShareLogs = 0) => {
     }),
     getReference: jest.fn((_entity, key) => ({ userKey: key })),
     flush: jest.fn(async () => undefined),
+    transactional: jest.fn(async (callback: (em: EmApi) => Promise<unknown>) =>
+      callback(em),
+    ),
   };
-  return {
-    em: {
-      transactional: jest.fn(
-        async (callback: (em: ForkApi) => Promise<unknown>) => callback(fork),
-      ),
-    },
-    fork,
-    persisted,
-  };
+  return { em, persisted };
 };
 
 const buildConfigService = () => ({
@@ -106,17 +104,103 @@ const buildExisting = (overrides: Partial<PlayChance> = {}): PlayChance =>
 
 describe("ChanceService", () => {
   describe("getMyChance", () => {
-    it("기존 row가 없으면 count=1로 초기화하여 반환한다", async () => {
-      const { em, fork } = buildEm(null);
+    it("기존 row가 없으면 무료 1회로 count=1을 반환한다", async () => {
+      const { em } = buildEm(null);
       const service = buildService(em);
 
-      const result = await service.getMyChance(1);
-
-      expect(result).toEqual({ count: 1 });
-      expect(fork.persist).toHaveBeenCalledTimes(1);
+      await expect(service.getMyChance(1)).resolves.toEqual({ count: 1 });
     });
 
-    it("lastResetAt이 어제면 count는 최소 1을 보장하고 lastResetAt 갱신", async () => {
+    it("무료 미사용(어제 사용) 상태면 충전분 + 무료 1을 더해 반환한다", async () => {
+      const existing = buildExisting({
+        count: 4,
+        lastResetAt: YESTERDAY_START,
+      });
+      const { em } = buildEm(existing);
+      const service = buildService(em);
+
+      await expect(service.getMyChance(1)).resolves.toEqual({ count: 5 });
+    });
+
+    it("오늘 무료를 이미 사용했으면 충전분만 반환한다", async () => {
+      const existing = buildExisting({ count: 5, lastResetAt: TODAY_START });
+      const { em } = buildEm(existing);
+      const service = buildService(em);
+
+      await expect(service.getMyChance(1)).resolves.toEqual({ count: 5 });
+    });
+
+    it("같은 KST 날짜의 다른 시각(KST 23:00)이어도 무료는 사용한 것으로 본다", async () => {
+      const existing = buildExisting({
+        count: 0,
+        lastResetAt: new Date("2026-05-09T14:00:00.000Z"), // KST 5/9 23:00
+      });
+      const { em } = buildEm(existing);
+      const service = buildService(em);
+
+      await expect(service.getMyChance(1)).resolves.toEqual({ count: 0 });
+    });
+
+    it("driver가 lastResetAt을 string으로 돌려줘도 KST 정규화 후 비교한다", async () => {
+      const existing = buildExisting({
+        count: 3,
+        lastResetAt: "2026-05-08T15:00:00.000Z" as unknown as Date,
+      });
+      const { em } = buildEm(existing);
+      const service = buildService(em);
+
+      await expect(service.getMyChance(1)).resolves.toEqual({ count: 3 });
+    });
+  });
+
+  describe("lost update 회귀 방지 (getMyChance 읽기 전용 불변식)", () => {
+    it("getMyChance는 persist/flush/transactional을 호출하지 않는다", async () => {
+      const existing = buildExisting({
+        count: 2,
+        lastResetAt: YESTERDAY_START,
+      });
+      const { em } = buildEm(existing);
+      const service = buildService(em);
+
+      await service.getMyChance(1);
+
+      expect(em.persist).not.toHaveBeenCalled();
+      expect(em.flush).not.toHaveBeenCalled();
+      expect(em.transactional).not.toHaveBeenCalled();
+    });
+
+    it("getMyChance는 row 객체를 수정하지 않는다", async () => {
+      const existing = buildExisting({
+        count: 2,
+        lastResetAt: YESTERDAY_START,
+      });
+      const { em } = buildEm(existing);
+      const service = buildService(em);
+
+      await service.getMyChance(1);
+
+      expect(existing.count).toBe(2);
+      expect(existing.lastResetAt).toBe(YESTERDAY_START);
+    });
+  });
+
+  describe("consumeWithEntityManager", () => {
+    it("당일 첫 플레이는 무료 — 충전분을 차감하지 않고 lastResetAt만 오늘로 갱신한다", async () => {
+      const existing = buildExisting({
+        count: 4,
+        lastResetAt: YESTERDAY_START,
+      });
+      const { em } = buildEm(existing);
+      const service = buildService(em);
+
+      await expect(
+        service.consumeWithEntityManager(em as never, 1),
+      ).resolves.toEqual({ count: 4 });
+      expect(existing.count).toBe(4);
+      expect(existing.lastResetAt).toEqual(TODAY_START);
+    });
+
+    it("무료 사용 가능하면 충전분이 0이어도 예외 없이 진행한다", async () => {
       const existing = buildExisting({
         count: 0,
         lastResetAt: YESTERDAY_START,
@@ -124,25 +208,71 @@ describe("ChanceService", () => {
       const { em } = buildEm(existing);
       const service = buildService(em);
 
-      const result = await service.getMyChance(1);
-
-      expect(result).toEqual({ count: 1 });
+      await expect(
+        service.consumeWithEntityManager(em as never, 1),
+      ).resolves.toEqual({ count: 0 });
       expect(existing.lastResetAt).toEqual(TODAY_START);
     });
 
-    it("같은 날짜면 count를 그대로 유지한다", async () => {
-      const existing = buildExisting({ count: 5 });
+    it("무료를 이미 썼고 충전분이 있으면 count를 1 차감한다", async () => {
+      const existing = buildExisting({ count: 3, lastResetAt: TODAY_START });
       const { em } = buildEm(existing);
       const service = buildService(em);
 
-      await expect(service.getMyChance(1)).resolves.toEqual({ count: 5 });
+      await expect(
+        service.consumeWithEntityManager(em as never, 1),
+      ).resolves.toEqual({ count: 2 });
+      expect(existing.count).toBe(2);
+    });
+
+    it("무료를 이미 썼고 충전분이 0이면 ConflictException + 변화 없음", async () => {
+      const existing = buildExisting({ count: 0, lastResetAt: TODAY_START });
+      const { em } = buildEm(existing);
+      const service = buildService(em);
+
+      await expect(
+        service.consumeWithEntityManager(em as never, 1),
+      ).rejects.toBeInstanceOf(ConflictException);
+      expect(existing.count).toBe(0);
+    });
+
+    it("row가 없으면 새로 생성하고 무료 플레이로 처리한다", async () => {
+      const { em, persisted } = buildEm(null);
+      const service = buildService(em);
+
+      await expect(
+        service.consumeWithEntityManager(em as never, 1),
+      ).resolves.toEqual({ count: 0 });
+      const created = persisted.find((p) => p instanceof PlayChance);
+      expect(created).toBeDefined();
+      expect(created?.lastResetAt).toEqual(TODAY_START);
+    });
+  });
+
+  describe("충전분 이월", () => {
+    it("충전분 4 보유 유저가 당일 첫 자동플레이를 해도 충전분은 4로 유지된다", async () => {
+      const existing = buildExisting({
+        count: 4,
+        lastResetAt: YESTERDAY_START,
+      });
+      const { em } = buildEm(existing);
+      const service = buildService(em);
+
+      await service.consumeWithEntityManager(em as never, 1);
+
+      expect(existing.count).toBe(4);
+      // 무료를 소진했으므로 이후 조회는 충전분 4만 반환
+      await expect(service.getMyChance(1)).resolves.toEqual({ count: 4 });
     });
   });
 
   describe("chargeByAd (광고 무제한)", () => {
-    it("화이트리스트 통과 시 count++ 와 AdView INSERT", async () => {
-      const existing = buildExisting({ count: 2 });
-      const { em, fork, persisted } = buildEm(existing);
+    it("무료 미사용 상태면 count++ 후 충전분+무료를 반환한다", async () => {
+      const existing = buildExisting({
+        count: 2,
+        lastResetAt: YESTERDAY_START,
+      });
+      const { em, persisted } = buildEm(existing);
       const chanceWhitelistValidator = buildWhitelistValidator();
       const service = buildService(em, chanceWhitelistValidator);
 
@@ -150,17 +280,26 @@ describe("ChanceService", () => {
         adGroupId: ALLOWED_AD_GROUP,
       });
 
-      expect(result).toEqual({ count: 3 });
-      const adViewCreated = persisted.find((p) => p instanceof AdView);
-      expect(adViewCreated).toBeDefined();
-      expect(fork.getReference).toHaveBeenCalled();
+      expect(result).toEqual({ count: 4 }); // 충전분 3 + 무료 1
+      expect(existing.count).toBe(3);
+      expect(persisted.find((p) => p instanceof AdView)).toBeDefined();
       expect(chanceWhitelistValidator.validateAdGroup).toHaveBeenCalledWith(1, {
         adGroupId: ALLOWED_AD_GROUP,
       });
     });
 
+    it("오늘 무료를 이미 썼으면 충전분만 반환한다", async () => {
+      const existing = buildExisting({ count: 2, lastResetAt: TODAY_START });
+      const { em } = buildEm(existing);
+      const service = buildService(em);
+
+      await expect(
+        service.chargeByAd(1, { adGroupId: ALLOWED_AD_GROUP }),
+      ).resolves.toEqual({ count: 3 });
+    });
+
     it("같은 사용자가 광고를 11번 시도해도 모두 통과 (캡 없음)", async () => {
-      const existing = buildExisting({ count: 0 });
+      const existing = buildExisting({ count: 0, lastResetAt: TODAY_START });
       const { em } = buildEm(existing);
       const chanceWhitelistValidator = buildWhitelistValidator();
       const service = buildService(em, chanceWhitelistValidator);
@@ -178,7 +317,7 @@ describe("ChanceService", () => {
 
   describe("chargeByShare", () => {
     it("contactsViral 채널: moduleId 통과 시 count++ 와 ShareLog INSERT", async () => {
-      const existing = buildExisting({ count: 1 });
+      const existing = buildExisting({ count: 1, lastResetAt: TODAY_START });
       const { em, persisted } = buildEm(existing, 0);
       const chanceWhitelistValidator = buildWhitelistValidator();
       const service = buildService(em, chanceWhitelistValidator);
@@ -191,8 +330,7 @@ describe("ChanceService", () => {
       });
 
       expect(result).toEqual({ count: 2 });
-      const shareLogCreated = persisted.find((p) => p instanceof ShareLog);
-      expect(shareLogCreated).toBeDefined();
+      expect(persisted.find((p) => p instanceof ShareLog)).toBeDefined();
       expect(chanceWhitelistValidator.validateShareModule).toHaveBeenCalledWith(
         1,
         expect.objectContaining({
@@ -203,7 +341,7 @@ describe("ChanceService", () => {
     });
 
     it("일일 캡(=5) 도달 시 거부", async () => {
-      const existing = buildExisting({ count: 5 });
+      const existing = buildExisting({ count: 5, lastResetAt: TODAY_START });
       const { em } = buildEm(existing, 5);
       const service = buildService(em);
 
@@ -217,7 +355,7 @@ describe("ChanceService", () => {
     });
 
     it("일일 캡 직전(4건)이면 통과 → 5번째 적립", async () => {
-      const existing = buildExisting({ count: 4 });
+      const existing = buildExisting({ count: 4, lastResetAt: TODAY_START });
       const { em } = buildEm(existing, 4);
       const service = buildService(em);
 
@@ -230,95 +368,9 @@ describe("ChanceService", () => {
     });
   });
 
-  describe("consumeWithEntityManager", () => {
-    it("count > 0이면 count-- 후 반환", async () => {
-      const existing = buildExisting({ count: 3 });
-      const { em, fork } = buildEm(existing);
-      const service = buildService(em);
-
-      await expect(
-        service.consumeWithEntityManager(fork as never, 1),
-      ).resolves.toEqual({
-        count: 2,
-      });
-      expect(existing.count).toBe(2);
-    });
-
-    it("count === 0이면 ConflictException + count 변화 없음", async () => {
-      const existing = buildExisting({ count: 0 });
-      const { em, fork } = buildEm(existing);
-      const service = buildService(em);
-
-      await expect(
-        service.consumeWithEntityManager(fork as never, 1),
-      ).rejects.toBeInstanceOf(ConflictException);
-      expect(existing.count).toBe(0);
-    });
-
-    it("자정 리셋 후 count는 최소 1이므로 consume 가능", async () => {
-      const existing = buildExisting({
-        count: 0,
-        lastResetAt: YESTERDAY_START,
-      });
-      const { em, fork } = buildEm(existing);
-      const service = buildService(em);
-
-      await expect(
-        service.consumeWithEntityManager(fork as never, 1),
-      ).resolves.toEqual({ count: 0 });
-      expect(existing.count).toBe(0);
-    });
-  });
-
-  describe("일일 리셋 (KST 정규화)", () => {
-    it("lastResetAt이 TODAY_START(=KST 자정의 UTC 시각)면 리셋되지 않고 count가 유지된다", async () => {
-      const existing = buildExisting({ count: 0, lastResetAt: TODAY_START });
-      const { em } = buildEm(existing);
-      const service = buildService(em);
-
-      await expect(service.getMyChance(1)).resolves.toEqual({ count: 0 });
-      expect(existing.count).toBe(0);
-    });
-
-    it("lastResetAt이 같은 KST 날짜의 다른 시각(KST 23:00)이어도 리셋되지 않는다", async () => {
-      const existing = buildExisting({
-        count: 0,
-        lastResetAt: new Date("2026-05-09T14:00:00.000Z"), // KST 5/9 23:00
-      });
-      const { em } = buildEm(existing);
-      const service = buildService(em);
-
-      await expect(service.getMyChance(1)).resolves.toEqual({ count: 0 });
-    });
-
-    it("lastResetAt이 driver로부터 string으로 들어와도 KST 정규화 후 비교한다", async () => {
-      const existing = buildExisting({
-        count: 3,
-        // 일부 driver는 datetime 컬럼을 string으로 돌려준다. 같은 KST 5/9이므로 유지돼야 한다.
-        lastResetAt: "2026-05-08T15:00:00.000Z" as unknown as Date,
-      });
-      const { em } = buildEm(existing);
-      const service = buildService(em);
-
-      await expect(service.getMyChance(1)).resolves.toEqual({ count: 3 });
-    });
-
-    it("같은 KST 날짜에 consume 후 다시 조회해도 count는 회복되지 않는다 (운영 버그 회귀)", async () => {
-      const existing = buildExisting({ count: 1, lastResetAt: TODAY_START });
-      const { em, fork } = buildEm(existing);
-      const service = buildService(em);
-
-      await service.consumeWithEntityManager(fork as never, 1);
-      expect(existing.count).toBe(0);
-
-      await expect(service.getMyChance(1)).resolves.toEqual({ count: 0 });
-      expect(existing.count).toBe(0);
-    });
-  });
-
   describe("transactional 래핑", () => {
     it("chargeByAd가 em.transactional 내부에서 실행된다", async () => {
-      const existing = buildExisting({ count: 0 });
+      const existing = buildExisting({ count: 0, lastResetAt: TODAY_START });
       const { em } = buildEm(existing);
       const service = buildService(em);
 
@@ -328,7 +380,7 @@ describe("ChanceService", () => {
     });
 
     it("chargeByShare가 em.transactional 내부에서 실행된다", async () => {
-      const existing = buildExisting({ count: 0 });
+      const existing = buildExisting({ count: 0, lastResetAt: TODAY_START });
       const { em } = buildEm(existing, 0);
       const service = buildService(em);
 

--- a/server-toss/src/modules/chance/chance.service.ts
+++ b/server-toss/src/modules/chance/chance.service.ts
@@ -1,4 +1,4 @@
-import { EntityManager } from "@mikro-orm/core";
+import { EntityManager, LockMode } from "@mikro-orm/core";
 import {
   ConflictException,
   ForbiddenException,
@@ -14,6 +14,10 @@ import { ChanceWhitelistValidator } from "./chance-whitelist.validator";
 import { PlayChance } from "./play-chance.entity";
 import { ShareChannel, ShareLog } from "./share-log.entity";
 
+// 기회 모델
+// - count: 광고/공유로 충전한 추가 기회. 일일 리셋 없이 다음 날로 이월된다.
+// - lastResetAt: 무료 플레이를 마지막으로 사용한 날(KST). 오늘보다 과거면 오늘 무료 1회 가능.
+// - 클라이언트에 노출하는 "기회 수" = count + (오늘 무료 가능 ? 1 : 0).
 @Injectable()
 export class ChanceService {
   private readonly logger = new Logger(ChanceService.name);
@@ -28,11 +32,12 @@ export class ChanceService {
       configService.get<number>("SHARE_DAILY_CHARGE_LIMIT") ?? 5;
   }
 
+  // 읽기 전용. DB를 수정하지 않으므로 차감(consume)과 동시에 호출돼도 lost update가 발생하지 않는다.
   async getMyChance(userKey: number): Promise<{ count: number }> {
-    return this.em.transactional(async (em) => {
-      const chance = await this.getOrInitWithReset(em, userKey);
-      return { count: chance.count };
-    });
+    const todayStart = getSeoulDayRange().start;
+    const chance = await this.em.findOne(PlayChance, { userKey });
+    if (!chance) return { count: 1 };
+    return { count: this.computeAvailable(chance, todayStart) };
   }
 
   async chargeByAd(
@@ -42,7 +47,8 @@ export class ChanceService {
     this.chanceWhitelistValidator.validateAdGroup(userKey, payload);
 
     return this.em.transactional(async (em) => {
-      const chance = await this.getOrInitWithReset(em, userKey);
+      const todayStart = getSeoulDayRange().start;
+      const chance = await this.findOrCreate(em, userKey);
 
       const userRef = em.getReference(User, userKey);
       const adView = em.create(AdView, {
@@ -55,7 +61,7 @@ export class ChanceService {
       this.successLog(userKey, "ad", chance.count, {
         adGroupId: payload.adGroupId,
       });
-      return { count: chance.count };
+      return { count: this.computeAvailable(chance, todayStart) };
     });
   }
 
@@ -67,7 +73,7 @@ export class ChanceService {
 
     return this.em.transactional(async (em) => {
       const { start, end } = getSeoulDayRange();
-      const chance = await this.getOrInitWithReset(em, userKey, start);
+      const chance = await this.findOrCreate(em, userKey);
 
       const todayShareLogs = await em.count(ShareLog, {
         user: { userKey },
@@ -90,7 +96,7 @@ export class ChanceService {
       this.successLog(userKey, "share", chance.count, {
         channel: payload.channel,
       });
-      return { count: chance.count };
+      return { count: this.computeAvailable(chance, start) };
     });
   }
 
@@ -98,7 +104,15 @@ export class ChanceService {
     em: EntityManager,
     userKey: number,
   ): Promise<{ count: number }> {
-    const chance = await this.getOrInitWithReset(em, userKey);
+    const todayStart = getSeoulDayRange().start;
+    const chance = await this.findOrCreate(em, userKey);
+
+    // 당일 첫 플레이는 무료 — 충전분(count)을 차감하지 않고 무료 사용일만 갱신한다.
+    if (this.isFreeAvailable(chance.lastResetAt, todayStart)) {
+      chance.lastResetAt = todayStart;
+      this.successLog(userKey, "consume", chance.count, { free: true });
+      return { count: chance.count };
+    }
 
     if (chance.count <= 0) {
       this.denyLog(userKey, "consume", "no_chance");
@@ -110,36 +124,42 @@ export class ChanceService {
     return { count: chance.count };
   }
 
-  private async getOrInitWithReset(
+  // 변경(차감/충전) 경로 전용. PESSIMISTIC_WRITE로 행을 잠가 동시 변경을 직렬화한다.
+  private async findOrCreate(
     em: EntityManager,
     userKey: number,
-    todayStart?: Date,
   ): Promise<PlayChance> {
-    const start = todayStart ?? getSeoulDayRange().start;
-    const existing = await em.findOne(PlayChance, { userKey });
+    const existing = await em.findOne(
+      PlayChance,
+      { userKey },
+      { lockMode: LockMode.PESSIMISTIC_WRITE },
+    );
+    if (existing) return existing;
 
-    if (!existing) {
-      const created = em.create(PlayChance, {
-        userKey,
-        count: 1,
-        lastResetAt: start,
-      });
-      em.persist(created);
-      return created;
-    }
+    // 새 행: lastResetAt을 epoch로 둬서 무료 플레이가 아직 사용 가능한 상태로 만든다.
+    const created = em.create(PlayChance, {
+      userKey,
+      count: 0,
+      lastResetAt: new Date(0),
+    });
+    em.persist(created);
+    return created;
+  }
 
-    // 양변을 KST 자정으로 정규화해서 비교한다. driver/컬럼 타입에 따라
-    // lastResetAt이 string("YYYY-MM-DD")이나 UTC 자정 Date로 들어와도
-    // 같은 KST 날짜라면 리셋 분기를 안 타도록 보장.
+  // 양변을 KST 자정으로 정규화해 비교한다. driver/컬럼 타입에 따라 lastResetAt이
+  // string("YYYY-MM-DD")이나 UTC 자정 Date로 들어와도 같은 KST 날짜면 동일하게 취급.
+  private isFreeAvailable(lastResetAt: Date, todayStart: Date): boolean {
     const lastResetSeoulStart = getSeoulDayRange(
-      new Date(existing.lastResetAt),
+      new Date(lastResetAt),
     ).start.getTime();
-    if (lastResetSeoulStart < start.getTime()) {
-      existing.count = Math.max(existing.count, 1);
-      existing.lastResetAt = start;
-    }
+    return lastResetSeoulStart < todayStart.getTime();
+  }
 
-    return existing;
+  private computeAvailable(chance: PlayChance, todayStart: Date): number {
+    const freeBonus = this.isFreeAvailable(chance.lastResetAt, todayStart)
+      ? 1
+      : 0;
+    return chance.count + freeBonus;
   }
 
   private successLog(

--- a/server-toss/src/modules/chance/play-chance.entity.ts
+++ b/server-toss/src/modules/chance/play-chance.entity.ts
@@ -2,8 +2,8 @@ import type { Opt } from "@mikro-orm/core";
 import { Entity, PrimaryKey, Property } from "@mikro-orm/decorators/legacy";
 
 // 카운터 테이블이라 User aggregate와 의도적으로 디커플링했어요 (FK 없음).
-// 사용자 삭제 시 잔여 행은 일일 reset 로직으로 자연스럽게 정리되며,
-// chance.service.getOrInitWithReset가 row가 없으면 새로 생성해 무결성을 보장해요.
+// 사용자 삭제 시 잔여 행이 남아도 chance.service.findOrCreate가 row가 없으면
+// 새로 생성하므로 무결성에는 영향이 없어요.
 @Entity({ tableName: "play_chances" })
 export class PlayChance {
   @PrimaryKey({
@@ -14,10 +14,11 @@ export class PlayChance {
   })
   userKey!: number;
 
+  // 광고/공유로 충전한 추가 기회. 일일 리셋 없이 다음 날로 이월된다.
   @Property({ type: "int", default: 0 })
-  // 나중에 기본 횟수가 바뀌어도 서비스 코드는 건드릴 필요가 없음
-  count: Opt<number> = 0; // default 책임이 엔티티 있음
+  count: Opt<number> = 0; // default 책임이 엔티티에 있음
 
+  // 무료 플레이를 마지막으로 사용한 날(KST 자정 기준). 오늘보다 과거면 오늘 무료 1회 가능.
   @Property({ fieldName: "last_reset_at", type: "datetime" })
   lastResetAt!: Date;
 }

--- a/server-toss/src/test-setup/setup-mikro-orm-mocks.ts
+++ b/server-toss/src/test-setup/setup-mikro-orm-mocks.ts
@@ -6,6 +6,16 @@ jest.mock("@mikro-orm/core", () => ({
   EntityRepository: class {},
   EntityRepositoryType: Symbol("EntityRepositoryType"),
   QueryOrder: { ASC: "asc", DESC: "desc" },
+  LockMode: {
+    NONE: 0,
+    OPTIMISTIC: 1,
+    PESSIMISTIC_READ: 2,
+    PESSIMISTIC_WRITE: 3,
+    PESSIMISTIC_PARTIAL_WRITE: 4,
+    PESSIMISTIC_WRITE_OR_FAIL: 5,
+    PESSIMISTIC_PARTIAL_READ: 6,
+    PESSIMISTIC_READ_OR_FAIL: 7,
+  },
 }));
 jest.mock("@mikro-orm/mysql", () => ({
   EntityManager: class {},


### PR DESCRIPTION
## 개요

당일 첫 자동 플레이에서 그리기 기회가 잘못 처리되는 문제를 수정했어요. 핵심은 서버의 기회 조회-차감 경합(lost update)이고, 검증하다 발견한 클라이언트 자동시작 이중 차감과 뒤로가기 재진입 루프도 함께 해결했어요.

## 관련 이슈

- Closes #387

## 변경 사항

### 바뀌기 전 상황

`chance.service.ts`의 private 헬퍼 `getOrInitWithReset`는 "오늘 첫 접근이면 `count = Math.max(count, 1)`, `lastResetAt = 오늘`"을 DB에 저장했어요. 이 헬퍼를 `getMyChance`(조회), `consumeWithEntityManager`(차감), `chargeBy*`(충전)가 모두 호출했고요.

조회인 `getMyChance`가 일일 리셋을 DB에 쓰는 게 문제였어요. 당일 첫 입장 자동시작 때 `GET /chances/me`와 `POST /plays/start`가 거의 동시에 발화되는데, 두 트랜잭션이 같은 리셋 전 값을 읽고 각자 UPDATE를 날려요. MySQL InnoDB는 기본 격리수준이 REPEATABLE READ이고 행 잠금이 없어서 늦게 커밋되는 쪽이 이겨요. 조회 트랜잭션이 차감 결과를 덮어쓰면 기회가 차감되지 않았어요(lost update).

또 `Math.max(count, 1)`이 "무료 1회 보장"과 "충전분 이월"을 한 변수에 뭉뚱그려서, 충전분을 가진 유저의 당일 첫 플레이가 충전분을 깎는 부작용도 있었어요.

### 바뀐 뒤 모델

- `count`는 광고·공유로 충전한 추가 기회만 의미해요. 일일 리셋 없이 다음 날로 이월돼요.
- `lastResetAt`은 무료 플레이를 마지막으로 쓴 날(KST)이에요. 오늘보다 과거면 오늘 무료 1회가 가능해요.
- 클라이언트에 주는 "기회 수"는 `count + (오늘 무료 가능하면 1, 아니면 0)`이에요.
- 당일 첫 플레이는 무료라 충전분을 깎지 않고, 그 다음부터 충전분에서 차감해요.

### 메서드별 변경

`getOrInitWithReset`를 제거하고 역할별로 셋으로 나눴어요.

- `isFreeAvailable(lastResetAt, todayStart)`: 순수 함수예요. KST 자정으로 정규화해서 무료 가능 여부만 판정하고, 쓰기는 없어요.
- `computeAvailable(chance, todayStart)`: 순수 함수예요. `count + freeBonus`를 계산해요.
- `findOrCreate(em, userKey)`: 변경(차감·충전) 경로 전용이에요. 행을 비관적 쓰기 잠금으로 조회하거나, 없으면 생성해요. 리셋은 하지 않아요.

`getMyChance`는 `em.transactional`과 쓰기를 없애고 `findOne` + `computeAvailable`만 남겨 읽기 전용으로 만들었어요.

`consumeWithEntityManager`는 `findOrCreate` 후 분기해요. 무료가 가능하면 `lastResetAt`만 오늘로 갱신하고 `count`는 그대로 두고, 무료를 이미 썼으면 `count`를 1 차감해요(0이면 `ConflictException`).

`chargeByAd`·`chargeByShare`는 `getOrInitWithReset` 대신 `findOrCreate`를 쓰도록 바꿔서 일일 리셋을 하지 않고 `count`만 1 올려요. 응답은 `computeAvailable`로 통일했어요.

### 비관적 락 적용

`getMyChance`를 읽기 전용으로 만들면 조회-차감 경합은 사라져요. 하지만 변경 경로끼리(`consume`과 `charge` 등)는 여전히 같은 행을 읽고-수정하고-써서 이들끼리도 lost update가 가능해요. MySQL 기본 SELECT는 잠금 없는 스냅샷 읽기라서요.

그래서 `findOrCreate`의 `em.findOne`에 `{ lockMode: LockMode.PESSIMISTIC_WRITE }`를 줘서 `SELECT ... FOR UPDATE`로 동작하게 했어요. 변경 트랜잭션이 행을 배타 잠금하므로, 동시에 들어온 다른 변경 트랜잭션은 앞 트랜잭션이 커밋될 때까지 기다렸다가 최신 값을 읽어요. `consume`과 `charge`는 모두 `em.transactional` 안에서 `findOrCreate`를 호출해서 잠금이 트랜잭션 끝까지 유지돼요. `getMyChance`는 읽기 전용이라 잠금이 필요 없고 잠금 경합도 만들지 않아요.

낙관적 락(버전 컬럼) 대신 비관적 락을 골랐어요. 충돌 시 재시도 로직이 필요 없고, 유저당 행이 하나뿐이라 경합 빈도가 낮아 잠금 대기 비용이 거의 없으며, `findOne` 옵션 한 줄로 끝나기 때문이에요.

### 클라이언트

자동시작 `useEffect`에 `useRef` 가드를 추가해서 effect가 두 번 실행돼도 `startPlay`를 마운트당 1회만 호출하게 했어요.

자동시작 게이트인 `lastPlayed`를 제출 시점이 아니라 게임 시작 시점에 기록하도록 바꿔서, 제출하지 않고 이탈해도 자동시작이 반복 발동하는 루프를 막았어요.

### 체크리스트

- [x] 코드 스타일 가이드/린트 규칙을 준수했어요.
- [x] 불필요한 콘솔/디버깅 코드를 제거했어요.
- [x] 주석/변수명 등 가독성을 고려했어요.
- [x] 영향 범위를 확인했어요. (다른 페이지/기능 깨짐 여부)
- [x] API, DB 변경 시 문서화했어요. (DB 마이그레이션은 필요 없어요 — 컬럼 유지, 의미·로직만 변경)
- [ ] 새로운 의존성 추가 시 팀과 공유했어요. (해당 없음)

## 테스트 및 검증 내용

- server-toss `pnpm test` 98개를 통과했어요. chance.service 신규 케이스(`getMyChance` 읽기 전용 불변식, 무료/유료 분기, 충전분 이월)를 포함해요.
- client-toss `pnpm test` 121개를 통과했고 lint·format·qa도 통과했어요.
- 토스 샌드박스에서 충전분 4로 리셋한 뒤 자동 플레이 1판을 하니 `count`가 4로 유지됐고, 게임 시작 후 뒤로가기를 해도 자동시작이 다시 발동하지 않는 걸 확인했어요.

## AI 활용 점검

동시성 lost update 원인 분석과 수정 설계, 테스트 케이스 작성에 Claude Code를 활용했어요.

## 추가 참고 사항

## 스크린샷 / UI 변경 (선택)

UI 변경은 없어요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 플레이 기회 상태 리셋 도구 추가

* **개선 사항**
  * 게임 시작 시 중복 자동 실행 방지
  * 플레이 기회 계산 및 관리 로직 최적화
  * 플레이 기회 초기화 방식 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/boostcampwm2025/web04-we-are-all-da-Vinci/pull/388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->