### PR TITLE
[fix] 광고 미준비 시 도전 버튼 게이팅 및 퍼널 이벤트 이중 집계 수정

### DIFF
--- a/client-toss/src/feature/playChance/config/constants.ts
+++ b/client-toss/src/feature/playChance/config/constants.ts
@@ -1,2 +1,5 @@
 export const PLAY_SESSION_STORAGE_KEY = "davinci:play-session";
 export const PLAY_SESSION_TTL_MS = 10 * 60 * 1000;
+
+/** 전면 광고 로드 타임아웃 — 이 시간 내 loaded 이벤트가 없으면 실패로 간주한다. */
+export const AD_LOAD_TIMEOUT_MS = 10 * 1000;

--- a/client-toss/src/feature/playChance/hooks/useFullScreenAd.test.ts
+++ b/client-toss/src/feature/playChance/hooks/useFullScreenAd.test.ts
@@ -20,6 +20,11 @@ describe("useFullScreenAd", () => {
     mockedLoad.mockReturnValue(vi.fn());
   });
 
+  // spyOn 복원을 일괄 보장 — 테스트 중간 실패 시에도 spy가 누수되지 않게 한다.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe("SDK 미지원 환경", () => {
     it("isSupported가 false면 즉시 ready 상태다", () => {
       mockedLoad.isSupported.mockReturnValue(false);
@@ -78,7 +83,8 @@ describe("useFullScreenAd", () => {
     });
 
     it("onError가 호출되면 failed 상태로 전환된다", () => {
-      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      // 광고 로드 실패 시 console.error가 호출되므로 출력만 억제한다(복원은 afterEach).
+      vi.spyOn(console, "error").mockImplementation(() => {});
       const { result } = renderHook(() => useFullScreenAd());
 
       act(() => {
@@ -86,7 +92,6 @@ describe("useFullScreenAd", () => {
       });
 
       expect(result.current.adStatus).toBe("failed");
-      errorSpy.mockRestore();
     });
 
     it("loaded 이후엔 타임아웃이 지나도 ready를 유지한다", () => {

--- a/client-toss/src/feature/playChance/hooks/useFullScreenAd.test.ts
+++ b/client-toss/src/feature/playChance/hooks/useFullScreenAd.test.ts
@@ -1,0 +1,120 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { loadFullScreenAd } from "@apps-in-toss/web-framework";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AD_LOAD_TIMEOUT_MS } from "../config/constants";
+import { useFullScreenAd } from "./useFullScreenAd";
+
+type AdHandlers = {
+  onEvent?: (event: { type: string }) => void;
+  onError?: (err: unknown) => void;
+};
+
+describe("useFullScreenAd", () => {
+  const mockedLoad = loadFullScreenAd as unknown as ReturnType<typeof vi.fn> & {
+    isSupported: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedLoad.mockReturnValue(vi.fn());
+  });
+
+  describe("SDK 미지원 환경", () => {
+    it("isSupported가 false면 즉시 ready 상태다", () => {
+      mockedLoad.isSupported.mockReturnValue(false);
+
+      const { result } = renderHook(() => useFullScreenAd());
+
+      expect(result.current.adStatus).toBe("ready");
+      expect(result.current.isAdLoaded).toBe(true);
+    });
+  });
+
+  describe("SDK 지원 환경", () => {
+    let handlers: AdHandlers;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      mockedLoad.isSupported.mockReturnValue(true);
+      handlers = {};
+      mockedLoad.mockImplementation((args: AdHandlers) => {
+        handlers.onEvent = args.onEvent;
+        handlers.onError = args.onError;
+        return vi.fn();
+      });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("마운트 직후엔 loading 상태다", () => {
+      const { result } = renderHook(() => useFullScreenAd());
+
+      expect(result.current.adStatus).toBe("loading");
+      expect(result.current.isAdLoaded).toBe(false);
+    });
+
+    it("loaded 이벤트가 오면 ready 상태로 전환된다", () => {
+      const { result } = renderHook(() => useFullScreenAd());
+
+      act(() => {
+        handlers.onEvent?.({ type: "loaded" });
+      });
+
+      expect(result.current.adStatus).toBe("ready");
+      expect(result.current.isAdLoaded).toBe(true);
+    });
+
+    it("로드 타임아웃이 지나면 failed 상태로 전환된다", () => {
+      const { result } = renderHook(() => useFullScreenAd());
+
+      act(() => {
+        vi.advanceTimersByTime(AD_LOAD_TIMEOUT_MS);
+      });
+
+      expect(result.current.adStatus).toBe("failed");
+    });
+
+    it("onError가 호출되면 failed 상태로 전환된다", () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const { result } = renderHook(() => useFullScreenAd());
+
+      act(() => {
+        handlers.onError?.(new Error("광고 인벤토리 없음"));
+      });
+
+      expect(result.current.adStatus).toBe("failed");
+      errorSpy.mockRestore();
+    });
+
+    it("loaded 이후엔 타임아웃이 지나도 ready를 유지한다", () => {
+      const { result } = renderHook(() => useFullScreenAd());
+
+      act(() => {
+        handlers.onEvent?.({ type: "loaded" });
+      });
+      act(() => {
+        vi.advanceTimersByTime(AD_LOAD_TIMEOUT_MS);
+      });
+
+      expect(result.current.adStatus).toBe("ready");
+    });
+
+    it("reloadAd 호출 시 loading 상태로 되돌아간다", () => {
+      const { result } = renderHook(() => useFullScreenAd());
+
+      act(() => {
+        vi.advanceTimersByTime(AD_LOAD_TIMEOUT_MS);
+      });
+      expect(result.current.adStatus).toBe("failed");
+
+      act(() => {
+        result.current.reloadAd();
+      });
+
+      expect(result.current.adStatus).toBe("loading");
+    });
+  });
+});

--- a/client-toss/src/feature/playChance/hooks/useFullScreenAd.ts
+++ b/client-toss/src/feature/playChance/hooks/useFullScreenAd.ts
@@ -4,38 +4,66 @@ import {
   showFullScreenAd,
 } from "@apps-in-toss/web-framework";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { AD_LOAD_TIMEOUT_MS } from "../config/constants";
 
 const FULL_SCREEN_AD_GROUP_ID = AD_GROUP_IDS.FULLSCREEN;
 
+/** 전면 광고 로드 상태 — loading: 로드 중, ready: 노출 가능, failed: 로드 실패/타임아웃. */
+export type AdStatus = "loading" | "ready" | "failed";
+
 export const useFullScreenAd = () => {
   const isSupported = loadFullScreenAd.isSupported();
-  // 광고 SDK 미지원(로컬 dev 등)에서는 곧바로 "로드 완료" 상태로 간주해 흐름 차단을 막는다.
-  const [isAdLoaded, setIsAdLoaded] = useState(!isSupported);
+  // 광고 SDK 미지원(로컬 dev 등)에서는 곧바로 "ready"로 간주해 흐름 차단을 막는다.
+  const [adStatus, setAdStatus] = useState<AdStatus>(
+    isSupported ? "loading" : "ready",
+  );
   const adUnregisterRef = useRef<(() => void) | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearLoadTimeout = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
 
   const registerAdLoader = useCallback(() => {
     adUnregisterRef.current?.();
+    clearLoadTimeout();
     if (!isSupported) return;
+    // 일정 시간 내 loaded 이벤트가 없으면 실패로 간주 — 버튼이 영구 로딩에 갇히는 것을 막는다.
+    timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = null;
+      setAdStatus("failed");
+    }, AD_LOAD_TIMEOUT_MS);
     adUnregisterRef.current = loadFullScreenAd({
       options: { adGroupId: FULL_SCREEN_AD_GROUP_ID },
       onEvent: (event) => {
-        if (event.type === "loaded") setIsAdLoaded(true);
+        if (event.type === "loaded") {
+          clearLoadTimeout();
+          setAdStatus("ready");
+        }
       },
-      onError: (err) => console.error("[광고 로드 실패]", err),
+      onError: (err) => {
+        console.error("[광고 로드 실패]", err);
+        clearLoadTimeout();
+        setAdStatus("failed");
+      },
     });
-  }, [isSupported]);
+  }, [clearLoadTimeout, isSupported]);
 
   useEffect(() => {
     registerAdLoader();
     return () => {
       adUnregisterRef.current?.();
       adUnregisterRef.current = null;
+      clearLoadTimeout();
     };
-  }, [registerAdLoader]);
+  }, [clearLoadTimeout, registerAdLoader]);
 
   const reloadAd = useCallback(() => {
     if (!isSupported) return;
-    setIsAdLoaded(false);
+    setAdStatus("loading");
     registerAdLoader();
   }, [isSupported, registerAdLoader]);
 
@@ -81,5 +109,11 @@ export const useFullScreenAd = () => {
     [isSupported, reloadAd],
   );
 
-  return { isAdLoaded, showAd, adGroupId: FULL_SCREEN_AD_GROUP_ID };
+  return {
+    adStatus,
+    isAdLoaded: adStatus === "ready",
+    showAd,
+    reloadAd,
+    adGroupId: FULL_SCREEN_AD_GROUP_ID,
+  };
 };

--- a/client-toss/src/feature/playChance/index.ts
+++ b/client-toss/src/feature/playChance/index.ts
@@ -1,8 +1,10 @@
 export {
+  AD_LOAD_TIMEOUT_MS,
   PLAY_SESSION_STORAGE_KEY,
   PLAY_SESSION_TTL_MS,
 } from "./config/constants";
 export { useFullScreenAd } from "./hooks/useFullScreenAd";
+export type { AdStatus } from "./hooks/useFullScreenAd";
 export { usePlayChance } from "./hooks/usePlayChance";
 export { useRequirePlaySession } from "./hooks/useRequirePlaySession";
 export { usePlayChanceContext } from "./model/playChanceContext";

--- a/client-toss/src/feature/share/model/useInviteFriend.test.tsx
+++ b/client-toss/src/feature/share/model/useInviteFriend.test.tsx
@@ -1,5 +1,6 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
 import { serverTossApi } from "@/shared/api";
+import { FUNNEL_EVENTS, trackClick } from "@/shared/lib";
 import { contactsViral } from "@apps-in-toss/web-framework";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -11,6 +12,12 @@ vi.mock("@/shared/api", () => ({
   },
 }));
 
+vi.mock("@/shared/lib", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/shared/lib")>("@/shared/lib");
+  return { ...actual, trackClick: vi.fn() };
+});
+
 describe("useInviteFriend", () => {
   const mockedContactsViral = contactsViral as unknown as ReturnType<
     typeof vi.fn
@@ -19,6 +26,7 @@ describe("useInviteFriend", () => {
   };
   const mockedCharge =
     serverTossApi.chargeChanceByShare as unknown as ReturnType<typeof vi.fn>;
+  const mockedTrackClick = vi.mocked(trackClick);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -53,6 +61,14 @@ describe("useInviteFriend", () => {
       expect(mockedContactsViral).not.toHaveBeenCalled();
       expect(onCharged).not.toHaveBeenCalled();
       expect(result.current.isInviting).toBe(false);
+      expect(mockedTrackClick).toHaveBeenCalledWith(
+        FUNNEL_EVENTS.shareInviteFailed,
+        { reason: "missing_module_id" },
+      );
+      expect(mockedTrackClick).not.toHaveBeenCalledWith(
+        FUNNEL_EVENTS.shareInviteRewardFailed,
+        expect.anything(),
+      );
     });
 
     it("moduleId는 있지만 contactsViral.isSupported false면 UNSUPPORTED 메시지로 차단된다", async () => {
@@ -144,6 +160,56 @@ describe("useInviteFriend", () => {
         });
         expect(onCharged).toHaveBeenCalledWith(2);
       });
+    });
+
+    it("적립 실패 시 shareInviteRewardFailed만 기록하고 shareInviteFailed는 기록하지 않는다", async () => {
+      mockedCharge.mockRejectedValueOnce(new Error("적립 서버 오류"));
+      let capturedOnEvent:
+        | ((event: {
+            type: string;
+            data: { rewardAmount: number; rewardUnit: string };
+          }) => void)
+        | undefined;
+      mockedContactsViral.mockImplementation(
+        ({
+          onEvent,
+        }: {
+          onEvent: (event: {
+            type: string;
+            data: { rewardAmount: number; rewardUnit: string };
+          }) => void;
+        }) => {
+          capturedOnEvent = onEvent;
+          return vi.fn();
+        },
+      );
+
+      const { result } = renderHook(() =>
+        useInviteFriend({ onError: vi.fn() }),
+      );
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      await act(async () => {
+        capturedOnEvent?.({
+          type: "sendViral",
+          data: { rewardAmount: 1, rewardUnit: "그리기 기회" },
+        });
+      });
+
+      await waitFor(() => {
+        expect(mockedTrackClick).toHaveBeenCalledWith(
+          FUNNEL_EVENTS.shareInviteRewardFailed,
+          expect.objectContaining({ reason: "적립 서버 오류" }),
+        );
+      });
+      // 적립 실패 경로에서 초대 실패 이벤트가 함께 집계되면 퍼널 지표가 왜곡된다.
+      expect(mockedTrackClick).not.toHaveBeenCalledWith(
+        FUNNEL_EVENTS.shareInviteFailed,
+        expect.anything(),
+      );
     });
   });
 });

--- a/client-toss/src/feature/share/model/useInviteFriend.ts
+++ b/client-toss/src/feature/share/model/useInviteFriend.ts
@@ -38,12 +38,11 @@ export const useInviteFriend = ({
     [],
   );
 
+  // 트래킹은 호출 지점별로 명시한다 — 초대 실패와 적립 실패가 한 함수에서 섞여
+  // 이중 집계되지 않도록, handleError는 onError 전파와 로깅만 담당한다.
   const handleError = useCallback(
     (err: unknown, fallback: string) => {
       const error = toError(err, fallback);
-      trackClick(FUNNEL_EVENTS.shareInviteFailed, {
-        reason: error.message,
-      });
       onError?.(error);
       console.error(`[useInviteFriend] ${fallback}`, error);
     },
@@ -87,7 +86,11 @@ export const useInviteFriend = ({
           }
         },
         onError: (err) => {
-          handleError(err, "공유 화면을 여는 중 오류가 났어요.");
+          const error = toError(err, "공유 화면을 여는 중 오류가 났어요.");
+          trackClick(FUNNEL_EVENTS.shareInviteFailed, {
+            reason: error.message,
+          });
+          handleError(error, "공유 화면을 여는 중 오류가 났어요.");
           cleanupRef.current?.();
           cleanupRef.current = null;
           setIsInviting(false);
@@ -103,6 +106,9 @@ export const useInviteFriend = ({
     if (!moduleId) {
       // VITE_CONTACTS_VIRAL_MODULE_ID가 빌드에 주입되지 않은 운영 사고 신호.
       // 사용자에게는 일반 메시지, 콘솔에는 명시적인 사유를 남겨 빠르게 감지한다.
+      trackClick(FUNNEL_EVENTS.shareInviteFailed, {
+        reason: "missing_module_id",
+      });
       handleError(
         "MISSING_MODULE_ID",
         "친구 초대 기능 설정에 문제가 있어요. 잠시 후 다시 시도해주세요.",
@@ -110,6 +116,9 @@ export const useInviteFriend = ({
       return;
     }
     if (!isContactsViralAvailable()) {
+      trackClick(FUNNEL_EVENTS.shareInviteFailed, {
+        reason: "unsupported",
+      });
       handleError(
         "UNSUPPORTED",
         "이 환경에서는 친구 초대 적립이 지원되지 않아요.",
@@ -120,7 +129,9 @@ export const useInviteFriend = ({
     try {
       startContactsViral(moduleId);
     } catch (err) {
-      handleError(err, "친구에게 공유하는 중 오류가 났어요.");
+      const error = toError(err, "친구에게 공유하는 중 오류가 났어요.");
+      trackClick(FUNNEL_EVENTS.shareInviteFailed, { reason: error.message });
+      handleError(error, "친구에게 공유하는 중 오류가 났어요.");
       setIsInviting(false);
     }
   }, [handleError, isInviting, moduleId, startContactsViral]);

--- a/client-toss/src/views/dashboard/ui/DashboardView.test.tsx
+++ b/client-toss/src/views/dashboard/ui/DashboardView.test.tsx
@@ -36,21 +36,31 @@ vi.mock("@/shared/api", () => ({
   setCachedNickname: vi.fn(),
 }));
 
+const mockShowAd = vi.fn().mockResolvedValue(undefined);
+const mockReloadAd = vi.fn();
+type AdStatus = "loading" | "ready" | "failed";
+const fullScreenAd = (adStatus: AdStatus) => ({
+  adStatus,
+  isAdLoaded: adStatus === "ready",
+  showAd: mockShowAd,
+  reloadAd: mockReloadAd,
+  adGroupId: "test-ad-group",
+});
+const mockUseFullScreenAd = vi.fn(() => fullScreenAd("ready"));
+const playChance = (hasChance: boolean) => ({
+  chanceCount: hasChance ? 1 : 0,
+  hasChance,
+  isLoading: false,
+  error: null,
+  refresh: mockRefresh,
+  chargeByAd: mockChargeByAd,
+  chargeByShare: vi.fn(),
+  startPlay: mockStartPlay,
+});
+const mockUsePlayChanceContext = vi.fn(() => playChance(true));
 vi.mock("@/feature/playChance", () => ({
-  useFullScreenAd: () => ({
-    isAdLoaded: false,
-    showAd: vi.fn().mockResolvedValue(undefined),
-  }),
-  usePlayChanceContext: () => ({
-    chanceCount: 1,
-    hasChance: true,
-    isLoading: false,
-    error: null,
-    refresh: mockRefresh,
-    chargeByAd: mockChargeByAd,
-    chargeByShare: vi.fn(),
-    startPlay: mockStartPlay,
-  }),
+  useFullScreenAd: () => mockUseFullScreenAd(),
+  usePlayChanceContext: () => mockUsePlayChanceContext(),
 }));
 
 vi.mock("@/entities/myScoreCard", () => ({
@@ -100,6 +110,8 @@ describe("DashboardView", () => {
     vi.clearAllMocks();
     localStorage.clear();
     vi.mocked(getDeviceId).mockResolvedValue({ deviceId: "test-device" });
+    mockUseFullScreenAd.mockImplementation(() => fullScreenAd("ready"));
+    mockUsePlayChanceContext.mockImplementation(() => playChance(true));
   });
 
   it("첫 방문 시 getPrompt 호출 후 /memorize로 이동한다", async () => {
@@ -234,6 +246,58 @@ describe("DashboardView", () => {
 
     await waitFor(() => {
       expect(navigateMock).toHaveBeenCalledWith("/memorize", expect.anything());
+    });
+  });
+
+  describe("잔여 기회 없음 — 광고 로드 상태별 도전 버튼", () => {
+    beforeEach(() => {
+      mockUsePlayChanceContext.mockImplementation(() => playChance(false));
+      localStorage.setItem("lastPlayed_test-device", formatLocalDate());
+    });
+
+    it("광고 로드 중이면 '광고 준비 중이에요' 버튼이 비활성으로 표시된다", async () => {
+      mockUseFullScreenAd.mockImplementation(() => fullScreenAd("loading"));
+
+      renderDashboard();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("my-ranking-section")).toBeInTheDocument();
+      });
+      expect(screen.getByText("광고 준비 중이에요")).toBeDisabled();
+    });
+
+    it("광고 로드 실패 시 '광고 다시 불러오기'를 누르면 reloadAd만 호출한다", async () => {
+      mockUseFullScreenAd.mockImplementation(() => fullScreenAd("failed"));
+      const user = userEvent.setup();
+
+      renderDashboard();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("my-ranking-section")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("광고 다시 불러오기"));
+
+      expect(mockReloadAd).toHaveBeenCalled();
+      expect(mockStartPlay).not.toHaveBeenCalled();
+    });
+
+    it("광고 로드 완료 시 '5초 광고 보고 도전하기'를 누르면 광고 흐름을 진행한다", async () => {
+      mockUseFullScreenAd.mockImplementation(() => fullScreenAd("ready"));
+      mockStartPlay.mockResolvedValueOnce({ promptId: 11, strokes: [] });
+      const user = userEvent.setup();
+
+      renderDashboard();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("my-ranking-section")).toBeInTheDocument();
+      });
+      await user.click(screen.getByText("5초 광고 보고 도전하기"));
+
+      await waitFor(() => {
+        expect(mockShowAd).toHaveBeenCalled();
+        expect(mockChargeByAd).toHaveBeenCalled();
+        expect(mockStartPlay).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/client-toss/src/views/dashboard/ui/DashboardView.tsx
+++ b/client-toss/src/views/dashboard/ui/DashboardView.tsx
@@ -42,7 +42,8 @@ const DashboardView = () => {
     startPlay,
     refresh: refreshChance,
   } = usePlayChanceContext();
-  const { isAdLoaded, showAd, adGroupId } = useFullScreenAd();
+  const { adStatus, isAdLoaded, showAd, reloadAd, adGroupId } =
+    useFullScreenAd();
 
   const [initialLoading, setInitialLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -203,6 +204,13 @@ const DashboardView = () => {
           });
           throw err;
         }
+      } else {
+        // 버튼은 adStatus가 "ready"일 때만 handleRetry를 연결하므로 정상 흐름엔 도달하지 않는 방어 가드.
+        trackClick(FUNNEL_EVENTS.adRewardFailed, {
+          ad_group_id: adGroupId,
+          reason: "ad_not_ready",
+        });
+        return;
       }
       const prompt = await startPlay();
       if (!prompt) {
@@ -248,6 +256,17 @@ const DashboardView = () => {
       setIsStartingGame(false);
     }
   };
+
+  // 잔여 기회가 없을 때의 광고 보상 버튼 — 광고 로드 상태에 따라 라벨·동작이 달라진다.
+  const adButton = {
+    loading: { label: "광고 준비 중이에요", onClick: undefined, busy: true },
+    failed: { label: "광고 다시 불러오기", onClick: reloadAd, busy: false },
+    ready: {
+      label: "5초 광고 보고 도전하기",
+      onClick: handleRetry,
+      busy: false,
+    },
+  }[adStatus];
 
   if (initialLoading) {
     return (
@@ -319,11 +338,11 @@ const DashboardView = () => {
           <Button
             color="primary"
             display="block"
-            loading={isStartingGame}
-            disabled={isStartingGame}
-            onClick={handleRetry}
+            loading={isStartingGame || adButton.busy}
+            disabled={isStartingGame || adButton.busy}
+            onClick={adButton.onClick}
           >
-            5초 광고 보고 도전하기
+            {adButton.label}
           </Button>
         )}
       </section>

--- a/client-toss/src/views/submitted/ui/SubmittedView.test.tsx
+++ b/client-toss/src/views/submitted/ui/SubmittedView.test.tsx
@@ -46,22 +46,30 @@ vi.mock("@/shared/ui/bannerAd", () => ({
 }));
 
 const mockShowAd = vi.fn().mockResolvedValue(undefined);
-const mockUseFullScreenAd = vi.fn(() => ({
-  isAdLoaded: false as boolean,
+const mockReloadAd = vi.fn();
+type AdStatus = "loading" | "ready" | "failed";
+const fullScreenAd = (adStatus: AdStatus) => ({
+  adStatus,
+  isAdLoaded: adStatus === "ready",
   showAd: mockShowAd,
-}));
+  reloadAd: mockReloadAd,
+  adGroupId: "test-ad-group",
+});
+const mockUseFullScreenAd = vi.fn(() => fullScreenAd("ready"));
+const playChance = (hasChance: boolean) => ({
+  chanceCount: hasChance ? 1 : 0,
+  hasChance,
+  isLoading: false,
+  error: null,
+  refresh: vi.fn(),
+  chargeByAd: mockChargeByAd,
+  chargeByShare: vi.fn(),
+  startPlay: mockStartPlay,
+});
+const mockUsePlayChanceContext = vi.fn(() => playChance(true));
 vi.mock("@/feature/playChance", () => ({
   useFullScreenAd: () => mockUseFullScreenAd(),
-  usePlayChanceContext: () => ({
-    chanceCount: 1,
-    hasChance: true,
-    isLoading: false,
-    error: null,
-    refresh: vi.fn(),
-    chargeByAd: mockChargeByAd,
-    chargeByShare: vi.fn(),
-    startPlay: mockStartPlay,
-  }),
+  usePlayChanceContext: () => mockUsePlayChanceContext(),
 }));
 
 const mockRouteState = {
@@ -94,10 +102,8 @@ describe("SubmittedView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
-    mockUseFullScreenAd.mockImplementation(() => ({
-      isAdLoaded: false,
-      showAd: mockShowAd,
-    }));
+    mockUseFullScreenAd.mockImplementation(() => fullScreenAd("ready"));
+    mockUsePlayChanceContext.mockImplementation(() => playChance(true));
   });
 
   it("점수와 완성 텍스트가 렌더링된다", () => {
@@ -254,10 +260,7 @@ describe("SubmittedView", () => {
 
   it("hasChance가 있으면 광고가 로드되어도 광고/chargeByAd 없이 startPlay만 호출한다", async () => {
     vi.useRealTimers();
-    mockUseFullScreenAd.mockImplementation(() => ({
-      isAdLoaded: true,
-      showAd: mockShowAd,
-    }));
+    mockUseFullScreenAd.mockImplementation(() => fullScreenAd("ready"));
     const user = userEvent.setup();
     mockStartPlay.mockResolvedValueOnce({
       promptId: 7,
@@ -281,8 +284,9 @@ describe("SubmittedView", () => {
     );
   });
 
-  it("광고가 로드되지 않은 경우 다시하기 시 광고/chargeByAd 없이 startPlay만 호출한다", async () => {
+  it("hasChance가 있으면 광고가 로드되지 않아도 광고/chargeByAd 없이 startPlay만 호출한다", async () => {
     vi.useRealTimers();
+    mockUseFullScreenAd.mockImplementation(() => fullScreenAd("loading"));
     const user = userEvent.setup();
     mockStartPlay.mockResolvedValueOnce({
       promptId: 8,
@@ -298,5 +302,49 @@ describe("SubmittedView", () => {
     });
     expect(mockShowAd).not.toHaveBeenCalled();
     expect(mockChargeByAd).not.toHaveBeenCalled();
+  });
+
+  describe("잔여 기회 없음 — 광고 로드 상태별 재도전 버튼", () => {
+    beforeEach(() => {
+      mockUsePlayChanceContext.mockImplementation(() => playChance(false));
+    });
+
+    it("광고 로드 중이면 '게임 준비 중' 버튼이 비활성으로 표시된다", () => {
+      mockUseFullScreenAd.mockImplementation(() => fullScreenAd("loading"));
+
+      renderWithState();
+
+      expect(screen.getByText("게임 준비 중")).toBeDisabled();
+    });
+
+    it("광고 로드 실패 시 '다시시작하기'를 누르면 reloadAd만 호출한다", async () => {
+      vi.useRealTimers();
+      mockUseFullScreenAd.mockImplementation(() => fullScreenAd("failed"));
+      const user = userEvent.setup();
+
+      renderWithState();
+
+      await user.click(screen.getByText("다시시작하기"));
+
+      expect(mockReloadAd).toHaveBeenCalled();
+      expect(mockStartPlay).not.toHaveBeenCalled();
+    });
+
+    it("광고 로드 완료 시 '등록 없이 재도전'을 누르면 광고 흐름을 진행한다", async () => {
+      vi.useRealTimers();
+      mockUseFullScreenAd.mockImplementation(() => fullScreenAd("ready"));
+      mockStartPlay.mockResolvedValueOnce({ promptId: 9, strokes: [] });
+      const user = userEvent.setup();
+
+      renderWithState();
+
+      await user.click(screen.getByText("등록 없이 재도전"));
+
+      await waitFor(() => {
+        expect(mockShowAd).toHaveBeenCalled();
+        expect(mockChargeByAd).toHaveBeenCalled();
+        expect(mockStartPlay).toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/client-toss/src/views/submitted/ui/SubmittedView.tsx
+++ b/client-toss/src/views/submitted/ui/SubmittedView.tsx
@@ -40,7 +40,8 @@ const SubmittedView = () => {
     trackScreen(FUNNEL_EVENTS.submittedView);
   }, [routeState]);
   const { hasChance, chargeByAd, startPlay } = usePlayChanceContext();
-  const { isAdLoaded, showAd, adGroupId } = useFullScreenAd();
+  const { adStatus, isAdLoaded, showAd, reloadAd, adGroupId } =
+    useFullScreenAd();
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isReplaying, setIsReplaying] = useState(false);
@@ -107,6 +108,14 @@ const SubmittedView = () => {
           });
           throw err;
         }
+      } else if (!hasChance) {
+        // 버튼은 adStatus가 "ready"일 때만 handleReplay를 연결하므로 정상 흐름엔 도달하지 않는 방어 가드.
+        trackClick(FUNNEL_EVENTS.adRewardFailed, {
+          ad_group_id: adGroupId,
+          reason: "ad_not_ready",
+        });
+        setIsReplaying(false);
+        return;
       }
       const prompt = await startPlay();
       if (!prompt) {
@@ -147,6 +156,27 @@ const SubmittedView = () => {
   if (!routeState) return null;
 
   const score = routeState.similarity?.score ?? 0;
+
+  // 재도전 버튼 — 잔여 기회가 있으면 광고 면제, 없으면 광고 로드 상태에 따라 라벨·동작이 달라진다.
+  const replayButton = hasChance
+    ? { label: "광고·등록 없이 재도전", onClick: handleReplay, busy: false }
+    : {
+        loading: {
+          label: "게임 준비 중",
+          onClick: undefined,
+          busy: true,
+        },
+        failed: {
+          label: "다시시작하기",
+          onClick: reloadAd,
+          busy: false,
+        },
+        ready: {
+          label: "등록 없이 재도전",
+          onClick: handleReplay,
+          busy: false,
+        },
+      }[adStatus];
 
   return (
     <div className="flex h-full flex-col bg-(--color-page)">
@@ -189,11 +219,11 @@ const SubmittedView = () => {
                 color="primary"
                 variant="weak"
                 display="block"
-                loading={isReplaying}
-                disabled={isReplaying || isSubmitting}
-                onClick={handleReplay}
+                loading={isReplaying || replayButton.busy}
+                disabled={isReplaying || isSubmitting || replayButton.busy}
+                onClick={replayButton.onClick}
               >
-                {hasChance ? "광고·등록 없이 재도전" : "등록 없이 재도전"}
+                {replayButton.label}
               </Button>
             </div>
             <div className="flex-1">


### PR DESCRIPTION
## 개요

앱인토스 미니앱에서 광고 보상으로 도전 기회를 충전하는 흐름에 두 가지 문제가 있어 수정했습니다.

1. 광고가 아직 로드되지 않았는데도 도전이 시도되어 사용자에게 잘못된 안내가 표시되는 문제
2. 친구 초대 실패 이벤트가 이중으로 집계되어 퍼널 지표가 왜곡되는 문제

## 관련 이슈

- Closes #395

## 변경 사항

### 1. 광고 로드 상태에 따른 도전 버튼 게이팅

**왜**

잔여 기회가 없을 때 광고 보상 버튼을 누르면, 광고가 아직 로드되지 않았더라도 광고 노출 단계를 건너뛰고 곧장 게임 시작(`startPlay`)이 호출됐습니다. 잔여 기회가 0이라 서버가 요청을 거절하고, 사용자에게는 "그리기 기회가 부족해요"라는 안내가 떴습니다. 실제로는 기회가 부족한 게 아니라 광고가 준비되지 않은 상태였기 때문에, 사용자가 원인을 오해하게 만드는 문구였습니다. (대시보드 재도전·제출 화면 재도전 모두 동일)

**어떻게**

- 광고 로드 상태를 `loading` / `ready` / `failed` 3단계로 관리하도록 `useFullScreenAd`를 확장했습니다. 로드 타임아웃(10초)과 SDK 에러를 `failed`로 구분하고, 광고를 다시 불러오는 `reloadAd`를 제공합니다.
- 광고 보상 버튼을 로드 상태에 따라 분기했습니다.
  - **로드 중**: 버튼 비활성 + 로딩 표시
  - **로드 실패**: 누르면 게임 시작이 아니라 광고를 다시 불러옴
  - **로드 완료**: 그때만 도전 흐름에 진입
- 광고가 준비되지 않은 채로 게임 시작에 도달하는 경로 자체를 제거하고, 핸들러에는 만일의 경합을 막는 방어 가드만 남겼습니다.

**결과**

광고가 준비되기 전에는 버튼이 "준비 중" 상태로 보여 사용자가 자연스럽게 기다릴 수 있고, 잘못된 "기회 부족" 안내가 더 이상 표시되지 않습니다. 광고 로드가 끝내 실패해도 다시 불러오기로 복구할 수 있어 버튼이 멈추지 않습니다.

### 2. 친구 초대 실패 이벤트 이중 집계 제거

**왜**

초대 공통 에러 처리(`handleError`)가 항상 초대 실패 이벤트를 기록했습니다. 적립 실패 경로는 이미 적립 실패 이벤트를 별도로 기록하고 있어, 한 번의 실패에 두 이벤트가 함께 쌓여 퍼널 지표가 부풀려졌습니다.

**어떻게**

- `handleError`는 에러 전파와 로깅만 담당하도록 바꾸고, 이벤트 기록은 초대 실패 호출 지점에서만 명시적으로 하도록 분리했습니다.

**결과**

초대 실패와 적립 실패가 각각 한 번씩만 집계되어 퍼널 단계별 지표가 정확해졌습니다.

### 체크리스트

- [x] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [x] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [x] 주석/변수명 등 가독성을 고려했습니다.
- [x] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [ ] API, DB 변경 시 문서화했습니다. — 해당 없음
- [ ] 새로운 의존성 추가 시 팀과 공유했습니다. — 해당 없음

## 테스트 및 검증 내용

- 전체 단위 테스트 **147개 통과** (`pnpm test`)
- `pnpm lint` 0 error, `pnpm qa` **8/8 PASS**
- 보강한 테스트
  - `useFullScreenAd.test.ts` (신규): 로드 완료 / 타임아웃 / 에러 / `reloadAd` 상태 전이 검증
  - `DashboardView.test.tsx`·`SubmittedView.test.tsx`: 광고 로드 상태별 버튼 렌더링, 방어 가드 경로
  - `useInviteFriend.test.tsx`: 적립 실패 시 적립 실패 이벤트만 기록되고 초대 실패 이벤트는 기록되지 않음을 검증

## AI 활용 점검

Claude Code로 문제 원인을 코드와 대조해 분석하고, 광고 로드 상태 게이팅 UX 설계·구현·테스트 작성을 진행했습니다.

## 추가 참고 사항

- 자동시작 진입 시 "다시 시도" 화면이 자주 뜨는 별개 버그(앱 콜드 스타트의 인증 토큰 재발급 경합)는 원인 분석을 마쳤으며, 별도 이슈로 추적할 예정입니다. 이번 PR 범위에 포함되지 않습니다.

## 스크린샷 / UI 변경 (선택)



