### PR TITLE
[fix] 대시보드 UI 정리 — 작은 화면 잘림·카드 정렬·도전 카드 반응형

### DIFF
--- a/client-toss/src/feature/playChance/ui/PlayNavButton.tsx
+++ b/client-toss/src/feature/playChance/ui/PlayNavButton.tsx
@@ -49,7 +49,7 @@ const PlayNavButton = () => {
           )}
         </span>
         <span
-          className="text-xs font-medium"
+          className="text-[11px] font-medium whitespace-nowrap"
           style={{ color: "var(--color-grey)" }}
         >
           테스트 시작

--- a/client-toss/src/index.css
+++ b/client-toss/src/index.css
@@ -182,3 +182,18 @@
   display: inline-block;
   animation: landing-bounce-arrow 1s ease-in-out infinite;
 }
+
+/* 높이 짧은 기기 안전망 — clamp(vh)로 부족할 때 마스코트·여백을 추가로 압축해
+   헤더+마스코트+CTA가 스크롤 없이 한 화면에 들어오게 한다. */
+@media (max-height: 700px) {
+  .landing-mascot {
+    max-height: 42vh;
+    bottom: 0;
+  }
+}
+
+@media (max-height: 560px) {
+  .landing-mascot {
+    max-height: 34vh;
+  }
+}

--- a/client-toss/src/shared/ui/bottomNav/BottomNav.tsx
+++ b/client-toss/src/shared/ui/bottomNav/BottomNav.tsx
@@ -32,7 +32,10 @@ export const NavItemButton = ({
       className="flex h-12 w-full flex-col items-center justify-center gap-0.5"
     >
       <MaskedIcon src={iconUrl} color={color} size={22} />
-      <span className="text-xs font-medium" style={{ color }}>
+      <span
+        className="text-[11px] font-medium whitespace-nowrap"
+        style={{ color }}
+      >
         {label}
       </span>
     </button>

--- a/client-toss/src/views/archive/ui/ArchiveView.tsx
+++ b/client-toss/src/views/archive/ui/ArchiveView.tsx
@@ -104,10 +104,12 @@ interface SummaryStatProps {
 }
 
 const SummaryStat = ({ iconName, label, value, unit }: SummaryStatProps) => (
-  <div className="flex min-w-0 flex-col items-center gap-1.5 border-r border-[#E5E8EB] px-2 last:border-r-0">
+  <div className="flex min-w-0 flex-col items-center gap-1.5 border-r border-[#E5E8EB] px-1 first:pl-0 last:border-r-0 last:pr-0">
     <Asset.Icon name={iconName} size="small" shape="original" alt="" />
-    <div className="text-xs font-medium text-(--color-grey)">{label}</div>
-    <div className="min-w-0 text-(--color-black)">
+    <div className="text-[11px] font-medium whitespace-nowrap text-(--color-grey)">
+      {label}
+    </div>
+    <div className="min-w-0 whitespace-nowrap text-(--color-black)">
       <span className="text-xl font-bold">{value}</span>
       {unit && <span className="text-sm font-normal">{unit}</span>}
     </div>
@@ -249,7 +251,7 @@ const ArchiveView = () => {
       />
 
       <section className="px-(--page-px)">
-        <div className="grid grid-cols-4 gap-0 rounded-(--radius-card) border border-[#E5E8EB] bg-white p-4 shadow-sm">
+        <div className="grid grid-cols-4 gap-0 rounded-(--radius-card) border border-[#E5E8EB] bg-white py-4 shadow-sm">
           <SummaryStat
             iconName="icon-calendar-check-yellow"
             label="그린 날"
@@ -459,7 +461,7 @@ const ArchiveView = () => {
                 onClick={() => setIsScoreDetailOpen(true)}
                 className="mt-5"
               >
-                기억력 점수 분석
+                기억력 점수 분석 보기
               </Button>
             </div>
           ) : null}

--- a/client-toss/src/views/dashboard/config/dashboardMock.ts
+++ b/client-toss/src/views/dashboard/config/dashboardMock.ts
@@ -10,8 +10,11 @@ export const STREAK_DAYS = 5;
 /** 오늘 획득한 포인트 */
 export const TODAY_POINTS = 4;
 
+/** 지금까지 받은 누적 포인트 */
+export const TOTAL_POINTS = 128;
+
 /** 내일도 참여하면 받는 보너스 포인트 */
-export const STREAK_BONUS_POINT = 2;
+export const STREAK_BONUS_POINT = 10;
 
 export interface TodayMission {
   id: string;

--- a/client-toss/src/views/dashboard/ui/ChallengeCard.tsx
+++ b/client-toss/src/views/dashboard/ui/ChallengeCard.tsx
@@ -1,10 +1,11 @@
 import { usePodium } from "@/entities/podium";
+import { brainImg, painterMan2Img } from "@/shared/assets/images";
 import { ShareSheet } from "@/feature/share";
 import { Button } from "@toss/tds-mobile";
 import { type ReactNode, useState } from "react";
 
 interface StatPillProps {
-  icon: string;
+  icon: ReactNode;
   label: string;
   value: string;
 }
@@ -37,22 +38,40 @@ const ChallengeCard = ({ cta }: ChallengeCardProps) => {
     <section className="rounded-(--radius-card) bg-(--color-card-yellow) p-5">
       <div className="flex items-stretch justify-between gap-3">
         <div className="flex flex-col gap-4">
-          <h2 className="text-xl leading-snug font-bold whitespace-nowrap text-(--color-black)">
-            10초 동안 기억하고
+          <h2 className="text-[22px] leading-tight font-bold whitespace-nowrap text-(--color-black)">
+            <span className="text-(--color-bronze)">10초</span> 동안{" "}
+            <span className="text-2xl text-(--color-bronze)">기억</span>하고
             <br />
-            30초 동안 그려요
+            <span className="text-(--color-bronze)">30초</span> 동안{" "}
+            <span className="text-2xl text-(--color-bronze)">그려요</span>
           </h2>
           <div className="flex flex-col items-start gap-2">
-            <StatPill icon="👥" label="오늘 참가자" value={participantText} />
-            <StatPill icon="🔥" label="오늘 최고점" value={topScore} />
+            <StatPill
+              icon={
+                <img
+                  src={painterMan2Img}
+                  alt=""
+                  className="h-6 w-6 object-contain"
+                />
+              }
+              label="오늘 참가자"
+              value={participantText}
+            />
+            <StatPill
+              icon={
+                <img src={brainImg} alt="" className="h-6 w-6 object-contain" />
+              }
+              label="오늘 최고점"
+              value={topScore}
+            />
           </div>
         </div>
         {/* 오늘의 그림은 도전 전까지 가려져 있어 ? placeholder로 표시.
             박스 높이는 왼쪽(제목+칩) 컬럼 높이에 맞춰 stretch된다. */}
-        <div className="flex w-28 shrink-0 items-center justify-center rounded-(--radius-inner) bg-(--color-card)">
+        <div className="flex w-28 min-w-0 shrink items-center justify-center rounded-(--radius-inner) bg-(--color-card)">
           <span
             aria-hidden
-            className="flex h-20 w-20 items-center justify-center rounded-full bg-(--color-gold) text-4xl font-bold text-white"
+            className="flex aspect-square w-[71%] items-center justify-center rounded-full bg-(--color-gold) text-4xl font-bold text-white"
           >
             ?
           </span>

--- a/client-toss/src/views/dashboard/ui/DashboardView.test.tsx
+++ b/client-toss/src/views/dashboard/ui/DashboardView.test.tsx
@@ -218,7 +218,7 @@ describe("DashboardView", () => {
       expect(screen.getByTestId("challenge-card")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText(/광고 없이.*번 도전/));
+    await user.click(screen.getByText(/광고 없이.*회 도전하기/));
 
     await waitFor(() => {
       expect(navigateMock).toHaveBeenCalledWith("/memorize", expect.anything());

--- a/client-toss/src/views/dashboard/ui/DashboardView.tsx
+++ b/client-toss/src/views/dashboard/ui/DashboardView.tsx
@@ -96,7 +96,7 @@ const DashboardView = () => {
         onClose={toast.close}
       />
 
-      <main className="min-h-0 flex-1 overflow-y-auto px-(--page-px) pt-3 pb-[calc(env(safe-area-inset-bottom)+56px)]">
+      <main className="min-h-0 flex-1 overflow-y-auto px-(--page-px) pt-3 pb-[calc(env(safe-area-inset-bottom)+72px)]">
         <div className="flex flex-col gap-3">
           <StreakStatsCard />
           <ChallengeCard cta={cta} />

--- a/client-toss/src/views/dashboard/ui/PlayCtaButton.tsx
+++ b/client-toss/src/views/dashboard/ui/PlayCtaButton.tsx
@@ -46,7 +46,7 @@ const PlayCtaButton = ({
         disabled={isStarting}
         onClick={onStart}
       >
-        {`광고 없이 ${chanceCount}번 도전`}
+        {`광고 없이 ${chanceCount}회 도전하기`}
       </Button>
     );
   }

--- a/client-toss/src/views/dashboard/ui/StreakStatsCard.tsx
+++ b/client-toss/src/views/dashboard/ui/StreakStatsCard.tsx
@@ -4,6 +4,7 @@ import {
   STREAK_BONUS_POINT,
   STREAK_DAYS,
   TODAY_POINTS,
+  TOTAL_POINTS,
 } from "../config/dashboardMock";
 
 interface StatItemProps {
@@ -12,8 +13,8 @@ interface StatItemProps {
 }
 
 const StatItem = ({ label, value }: StatItemProps) => (
-  <div className="flex flex-1 flex-col items-start gap-1.5 px-3">
-    <span className="text-[13px] whitespace-nowrap text-(--color-grey)">
+  <div className="flex min-w-0 flex-1 flex-col items-center gap-1.5 px-1">
+    <span className="text-[11px] whitespace-nowrap text-(--color-grey)">
       {label}
     </span>
     <span className="text-[17px] leading-none font-bold text-(--color-black)">
@@ -28,7 +29,7 @@ const StreakStatsCard = () => {
 
   // 로딩 중에는 myRanking이 undefined → found=false → 두 값 모두 "-"로 표시
   const found = myRanking?.state === "FOUND";
-  const scoreText = found ? `${myRanking.ranking.score}` : "-";
+  const scoreText = found ? `${myRanking.ranking.score}점` : "-";
   const rankText = found ? `${myRanking.ranking.rank}위` : "-";
 
   return (
@@ -49,7 +50,7 @@ const StreakStatsCard = () => {
               <span className="text-base">연속 참여 중!</span>
             </p>
             <p className="mt-1 text-[13px] text-(--color-grey)">
-              내일도 참여하면 +{STREAK_BONUS_POINT}P
+              내일도 참여하면 최대 {STREAK_BONUS_POINT}P
             </p>
           </div>
         </div>
@@ -67,11 +68,13 @@ const StreakStatsCard = () => {
       </div>
 
       <div className="mt-5 flex items-stretch rounded-(--radius-inner) bg-(--color-page) py-4">
-        <StatItem label="당일 획득 포인트" value={`${TODAY_POINTS}P`} />
+        <StatItem label="누적 포인트" value={`${TOTAL_POINTS}P`} />
         <div className="my-1 w-px self-stretch bg-(--color-card)" />
-        <StatItem label="기억력 점수" value={scoreText} />
+        <StatItem label="오늘 포인트" value={`${TODAY_POINTS}P`} />
         <div className="my-1 w-px self-stretch bg-(--color-card)" />
-        <StatItem label="오늘 순위" value={rankText} />
+        <StatItem label="오늘 점수" value={scoreText} />
+        <div className="my-1 w-px self-stretch bg-(--color-card)" />
+        <StatItem label="현재 순위" value={rankText} />
       </div>
     </section>
   );

--- a/client-toss/src/views/dashboard/ui/TodayDavinciCard.tsx
+++ b/client-toss/src/views/dashboard/ui/TodayDavinciCard.tsx
@@ -40,7 +40,7 @@ const TodayDavinciCard = () => {
       <button
         type="button"
         onClick={() => navigate("/ranking")}
-        className="flex w-full items-center justify-between"
+        className="flex w-full items-baseline justify-between"
       >
         <h2 className="text-base font-bold text-(--color-black)">
           오늘의 다빈치

--- a/client-toss/src/views/dashboard/ui/TodayMissionCard.tsx
+++ b/client-toss/src/views/dashboard/ui/TodayMissionCard.tsx
@@ -21,27 +21,45 @@ const MissionTile = ({ label, point, done }: TodayMission) => (
         {label}
       </span>
     </div>
-    <span className="self-start rounded-full bg-(--color-page) px-2 py-0.5 text-xs font-bold text-(--color-toss-blue)">
+    {/* 미완 미션은 보상 pill을 채운 파랑으로 강조해 "도전해서 받기"를 유도(재도전 레버) */}
+    <span
+      className={`self-start rounded-full px-2 py-0.5 text-xs font-bold ${
+        done
+          ? "bg-(--color-page) text-(--color-toss-blue)"
+          : "bg-(--color-toss-blue) text-white"
+      }`}
+    >
       +{point}P
     </span>
   </div>
 );
 
-const TodayMissionCard = () => (
-  <section className="rounded-(--radius-card) border border-(--color-card) bg-(--color-page) p-4">
-    <div className="flex items-center justify-between">
-      <h2 className="text-base font-bold text-(--color-black)">오늘의 미션</h2>
-      {/* 포인트 더 받기: 진입 라우트가 아직 없어 비활성 라벨로만 노출 (스왑 시 연결) */}
-      <span className="text-[13px] font-medium text-(--color-grey)">
-        포인트 더 받기 ›
-      </span>
-    </div>
-    <div className="mt-3 flex gap-2">
-      {TODAY_MISSIONS.map((mission) => (
-        <MissionTile key={mission.id} {...mission} />
-      ))}
-    </div>
-  </section>
-);
+const TodayMissionCard = () => {
+  const doneCount = TODAY_MISSIONS.filter((mission) => mission.done).length;
+
+  return (
+    <section className="rounded-(--radius-card) border border-(--color-card) bg-(--color-page) p-4">
+      <div className="flex items-baseline justify-between">
+        <div className="flex items-baseline gap-1.5">
+          <h2 className="text-base font-bold text-(--color-black)">
+            오늘의 미션
+          </h2>
+          <span className="rounded-full bg-(--color-card) px-2 py-0.5 text-[11px] font-bold text-(--color-grey)">
+            {doneCount}/{TODAY_MISSIONS.length}
+          </span>
+        </div>
+        {/* 포인트 더 받기: 진입 라우트가 아직 없어 비활성 라벨로만 노출 (스왑 시 연결) */}
+        <span className="text-[13px] font-medium text-(--color-grey)">
+          포인트 더 받기 ›
+        </span>
+      </div>
+      <div className="mt-3 flex gap-2">
+        {TODAY_MISSIONS.map((mission) => (
+          <MissionTile key={mission.id} {...mission} />
+        ))}
+      </div>
+    </section>
+  );
+};
 
 export default TodayMissionCard;

--- a/client-toss/src/views/landing/ui/LandingView.tsx
+++ b/client-toss/src/views/landing/ui/LandingView.tsx
@@ -40,14 +40,14 @@ const LandingView = ({ onStart }: LandingViewProps) => {
   return (
     <div
       data-no-safe-area-bottom
-      className="pt-8 relative flex h-full flex-col overflow-hidden bg-(--color-page)"
+      className="landing-root pt-[clamp(0.75rem,3vh,2rem)] relative flex h-full flex-col overflow-hidden bg-(--color-page)"
     >
       <div
         ref={confettiRef}
         className="pointer-events-none absolute inset-0 overflow-hidden"
       />
 
-      <section className="relative z-10 mt-6 px-(--page-px) text-center">
+      <section className="relative z-10 mt-[clamp(0.5rem,2.5vh,1.5rem)] px-(--page-px) text-center">
         <p
           className="text-sm font-semibold"
           style={{ color: "rgba(0,12,30,0.55)" }}
@@ -55,7 +55,7 @@ const LandingView = ({ onStart }: LandingViewProps) => {
           그림 그리고 파악하는 나의 기억력
         </p>
         <h1
-          className="mt-2 mb-3 text-3xl font-extrabold leading-tight"
+          className="mt-2 mb-3 text-[clamp(1.5rem,5vh,1.875rem)] font-extrabold leading-tight"
           style={{ color: "rgba(0,12,30,0.88)" }}
         >
           당신의 기억력
@@ -69,8 +69,8 @@ const LandingView = ({ onStart }: LandingViewProps) => {
           매일 기억력 테스트하고 토스 포인트 받아요!
         </p>
       </section>
-      <section className="relative z-10 mt-4 flex flex-1 items-center justify-center">
-        <div className="landing-float relative w-full max-w-sm px-4">
+      <section className="relative z-10 mt-[clamp(0.5rem,2vh,1rem)] flex min-h-0 flex-1 items-center justify-center">
+        <div className="landing-float relative flex h-full w-full max-w-sm items-center justify-center px-4">
           <span
             className="absolute top-20 right-8 flex h-1.5 w-1.5 animate-ping rounded-full bg-blue-300 opacity-60"
             style={{ animationDelay: "0.5s" }}
@@ -87,17 +87,17 @@ const LandingView = ({ onStart }: LandingViewProps) => {
           >
             ((
           </span>
-          <div className="bottom-16 relative z-10 flex aspect-square w-full items-center justify-center">
+          <div className="landing-mascot bottom-[clamp(0rem,4vh,4rem)] relative z-10 flex h-full max-h-full w-full items-center justify-center">
             <img
               src={landing}
               alt="우리 모두 다빈치 마스코트"
-              className="h-full w-full object-contain drop-shadow-xl"
+              className="h-full max-h-full w-full object-contain drop-shadow-xl"
             />
           </div>
         </div>
       </section>
       <div className="pointer-events-none absolute bottom-0 h-32 w-full bg-linear-to-t from-(--color-page) to-transparent" />
-      <footer className="relative z-10 flex flex-col items-center gap-4 px-(--page-px) pt-3 pb-[env(safe-area-inset-bottom)]">
+      <footer className="relative z-10 flex flex-col items-center gap-[clamp(0.5rem,2vh,1rem)] px-(--page-px) pt-[clamp(0.5rem,1.5vh,0.75rem)] pb-[env(safe-area-inset-bottom)]">
         <div
           className="landing-float flex items-center gap-2"
           style={{ animationDuration: "3s" }}


### PR DESCRIPTION
## 개요

client-toss 대시보드/공통 UI를 더 작은 휴대폰 화면 기준으로 개선했어요.
랜딩 잘림, 아카이브·연속참여·미션·다빈치 카드 정렬, 도전 카드 반응형, 하단 바텀nav 가림을 수정했어요.

## 관련 이슈

- #409

## 변경 사항

- 랜딩: 높이 짧은 기기에서 스크롤 없이 한 화면에 들어오도록 마스코트·여백 clamp + 짧은 화면 미디어쿼리
- 아카이브: 상단 통계 카드 라벨 nowrap·정렬 정리
- 연속참여 카드: 포인트를 "누적 / 오늘"로 분리(4칸), 점수 단위 표기
- 미션 카드: 진행 1/2 배지, 미완 미션 보상 강조, 헤더 베이스라인 정렬
- 다빈치 카드: 헤더 베이스라인 정렬
- 도전 카드: 헤더·아이콘 정리, 오른쪽 그림 박스 반응형(공간 부족 시에만 축소, 비율 유지)
- 하단: 대시보드 콘텐츠가 바텀nav/FAB에 가리지 않도록 하단 여백 보정, 하단바 라벨 nowrap

### 체크리스트

- [x] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [x] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [x] 주석/변수명 등 가독성을 고려했습니다.
- [x] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [ ] API, DB 변경 시 문서화했습니다. (해당 없음)
- [ ] 새로운 의존성 추가 시 팀과 공유했습니다. (해당 없음)

## 테스트 및 검증 내용

클라이어트 전체 테스트 통과

## AI 활용 점검

Claude Code로 작은 화면 레이아웃 진단·정렬/반응형 수정·테스트 실행을 진행했어요.

## 추가 참고 사항

## 스크린샷 / UI 변경 (선택)

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/887cf66d-bfe3-436d-9bf0-1657512c72ea" />
