### PR TITLE
[fix] 일일/주간 미션을 구분해서 할당하도록 수정

### DIFF
--- a/server-toss/src/modules/mission/service/assign-mission.service.ts
+++ b/server-toss/src/modules/mission/service/assign-mission.service.ts
@@ -29,10 +29,24 @@ export class AssignMissionService {
       todayStart,
       weekStart,
     );
-    if (existing.length > 0) return;
+
+    const hasDaily = existing.some(
+      (um) => um.mission.period === MissionPeriod.DAILY,
+    );
+    const hasWeekly = existing.some(
+      (um) => um.mission.period === MissionPeriod.WEEKLY,
+    );
+
+    if (hasDaily && hasWeekly) return;
 
     try {
-      await this.assignNewMissions(userKey, todayStart, weekStart);
+      await this.assignNewMissions(
+        userKey,
+        todayStart,
+        weekStart,
+        !hasDaily,
+        !hasWeekly,
+      );
     } catch (err) {
       if (!this.isDuplicateKeyError(err)) throw err;
     }
@@ -43,19 +57,25 @@ export class AssignMissionService {
     userKey: number,
     todayStart: Date,
     weekStart: Date,
+    needsDaily: boolean,
+    needsWeekly: boolean,
   ): Promise<UserMission[]> {
-    const dailyMissions = await this.assignMissions(
-      userKey,
-      MissionPeriod.DAILY,
-      todayStart,
-      DAILY_RANDOM_COUNT,
-    );
-    const weeklyMissions = await this.assignMissions(
-      userKey,
-      MissionPeriod.WEEKLY,
-      weekStart,
-      WEEKLY_RANDOM_COUNT,
-    );
+    const dailyMissions = needsDaily
+      ? await this.assignMissions(
+          userKey,
+          MissionPeriod.DAILY,
+          todayStart,
+          DAILY_RANDOM_COUNT,
+        )
+      : [];
+    const weeklyMissions = needsWeekly
+      ? await this.assignMissions(
+          userKey,
+          MissionPeriod.WEEKLY,
+          weekStart,
+          WEEKLY_RANDOM_COUNT,
+        )
+      : [];
 
     const all = [...dailyMissions, ...weeklyMissions];
     if (all.length > 0) {

--- a/server-toss/src/modules/mission/test/assign-mission.service.spec.ts
+++ b/server-toss/src/modules/mission/test/assign-mission.service.spec.ts
@@ -1,0 +1,186 @@
+import { Test } from "@nestjs/testing";
+import {
+  Mission,
+  MissionPeriod,
+  ObjectiveType,
+  ProgressPeriod,
+  RewardType,
+} from "../entity/mission.entity";
+import { UserMission } from "../entity/user-mission.entity";
+import { MissionWindow } from "../mission-window";
+import { AssignMissionService } from "../service/assign-mission.service";
+
+const MISSION_REPO_TOKEN = "MissionRepository";
+const USER_MISSION_REPO_TOKEN = "UserMissionRepository";
+
+const TODAY_START = new Date("2026-06-18T15:00:00.000Z");
+const WEEK_START = new Date("2026-06-15T15:00:00.000Z");
+
+const window = {
+  todayStart: TODAY_START,
+  todayEnd: new Date("2026-06-19T15:00:00.000Z"),
+  weekStart: WEEK_START,
+  monthStart: new Date("2026-05-31T15:00:00.000Z"),
+  now: new Date("2026-06-19T03:00:00.000Z"),
+} as MissionWindow;
+
+const buildMission = (overrides: Partial<Mission> = {}): Mission =>
+  ({
+    id: BigInt(1),
+    title: "테스트 미션",
+    period: MissionPeriod.DAILY,
+    isFixed: true,
+    objectiveType: ObjectiveType.SUBMIT,
+    requiredCount: 3,
+    threshold: null,
+    rewardType: RewardType.POINT,
+    rewardAmount: 10,
+    progressPeriod: ProgressPeriod.NONE,
+    ...overrides,
+  }) as Mission;
+
+const buildUserMission = (overrides: Partial<UserMission> = {}): UserMission =>
+  ({
+    id: BigInt(1),
+    user: { userKey: 1 },
+    mission: buildMission(),
+    currentCount: 0,
+    completedAt: null,
+    lastProgressedAt: null,
+    createdAt: TODAY_START,
+    ...overrides,
+  }) as unknown as UserMission;
+
+describe("미션 배정 서비스", () => {
+  let service: AssignMissionService;
+  let missionRepository: Record<string, jest.Mock>;
+  let userMissionRepository: Record<string, jest.Mock>;
+
+  beforeEach(async () => {
+    missionRepository = {
+      findFixed: jest.fn(async () => [buildMission()]),
+      findRandom: jest.fn(async () => []),
+    };
+    userMissionRepository = {
+      findCurrentMissions: jest.fn(async () => []),
+      createForUser: jest.fn((_userKey, mission, periodStart) =>
+        buildUserMission({ mission, createdAt: periodStart }),
+      ),
+      flush: jest.fn(async () => undefined),
+    };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        {
+          provide: AssignMissionService,
+          useFactory: (missionRepo, userMissionRepo) =>
+            new AssignMissionService(missionRepo, userMissionRepo),
+          inject: [MISSION_REPO_TOKEN, USER_MISSION_REPO_TOKEN],
+        },
+        { provide: MISSION_REPO_TOKEN, useValue: missionRepository },
+        { provide: USER_MISSION_REPO_TOKEN, useValue: userMissionRepository },
+      ],
+    }).compile();
+
+    service = module.get(AssignMissionService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe("배정된 미션이 없으면", () => {
+    it("일일 미션과 주간 미션을 모두 배정한다", async () => {
+      await service.ensureMissionsAssigned(1, window);
+
+      expect(missionRepository.findFixed).toHaveBeenCalledWith(
+        MissionPeriod.DAILY,
+      );
+      expect(missionRepository.findFixed).toHaveBeenCalledWith(
+        MissionPeriod.WEEKLY,
+      );
+      expect(userMissionRepository.flush).toHaveBeenCalled();
+    });
+  });
+
+  describe("주간 미션만 존재하면", () => {
+    it("일일 미션만 배정한다", async () => {
+      userMissionRepository.findCurrentMissions.mockResolvedValue([
+        buildUserMission({
+          mission: buildMission({ period: MissionPeriod.WEEKLY }),
+          createdAt: WEEK_START,
+        }),
+      ]);
+
+      await service.ensureMissionsAssigned(1, window);
+
+      expect(missionRepository.findFixed).toHaveBeenCalledWith(
+        MissionPeriod.DAILY,
+      );
+      expect(missionRepository.findFixed).not.toHaveBeenCalledWith(
+        MissionPeriod.WEEKLY,
+      );
+    });
+  });
+
+  describe("일일 미션만 존재하면", () => {
+    it("주간 미션만 배정한다", async () => {
+      userMissionRepository.findCurrentMissions.mockResolvedValue([
+        buildUserMission({
+          mission: buildMission({ period: MissionPeriod.DAILY }),
+        }),
+      ]);
+
+      await service.ensureMissionsAssigned(1, window);
+
+      expect(missionRepository.findFixed).not.toHaveBeenCalledWith(
+        MissionPeriod.DAILY,
+      );
+      expect(missionRepository.findFixed).toHaveBeenCalledWith(
+        MissionPeriod.WEEKLY,
+      );
+    });
+  });
+
+  describe("일일 미션과 주간 미션이 모두 존재하면", () => {
+    it("새로운 미션을 배정하지 않는다", async () => {
+      userMissionRepository.findCurrentMissions.mockResolvedValue([
+        buildUserMission({
+          mission: buildMission({ period: MissionPeriod.DAILY }),
+        }),
+        buildUserMission({
+          mission: buildMission({ period: MissionPeriod.WEEKLY }),
+          createdAt: WEEK_START,
+        }),
+      ]);
+
+      await service.ensureMissionsAssigned(1, window);
+
+      expect(missionRepository.findFixed).not.toHaveBeenCalled();
+      expect(userMissionRepository.flush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("동시 요청으로 중복 키 에러가 발생하면", () => {
+    it("ER_DUP_ENTRY는 무시한다", async () => {
+      const dupError = Object.assign(new Error("Duplicate entry"), {
+        code: "ER_DUP_ENTRY",
+      });
+      userMissionRepository.flush.mockRejectedValue(dupError);
+
+      await expect(
+        service.ensureMissionsAssigned(1, window),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("중복 키가 아닌 에러가 발생하면", () => {
+    it("에러를 다시 throw한다", async () => {
+      userMissionRepository.flush.mockRejectedValue(
+        new Error("Connection lost"),
+      );
+
+      await expect(service.ensureMissionsAssigned(1, window)).rejects.toThrow(
+        "Connection lost",
+      );
+    });
+  });
+});


### PR DESCRIPTION


## 개요

- 일일/주간 미션을 구분없이 개수를 검증하는 구조 때문에
- 주간 미션만 존재하는 경우, 일일미션을 생성하지 않고 리턴하는 버그 존재
- 일일/주간 미션을 구분해서 검증하고 생성하도록 수정
- 추가로, 버그 검증 테스트 코드 보완

## 관련 이슈

- Close #400 

## 변경 사항

```ts
    const existing = await this.userMissionRepository.findCurrentMissions(
      userKey,
      todayStart,
      weekStart,
    );
    // 기존
    if (existing.length > 0) return;

    // 수정
    const hasDaily = existing.some(
      (um) => um.mission.period === MissionPeriod.DAILY,
    );
    const hasWeekly = existing.some(
      (um) => um.mission.period === MissionPeriod.WEEKLY,
    );

    if (hasDaily && hasWeekly) return;
```
### 체크리스트

<!-- 리뷰 전에 본인이 확인해야 하는 항목 -->

- [ ] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [ ] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [ ] 주석/변수명 등 가독성을 고려했습니다.
- [ ] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [ ] API, DB 변경 시 문서화했습니다.
- [ ] 새로운 의존성 추가 시 팀과 공유했습니다.

## 테스트 및 검증 내용

<img width="616" height="575" alt="스크린샷 2026-06-19 02 07 28" src="https://github.com/user-attachments/assets/7b4ec780-bc18-43a5-9d2a-5e015235d2c1" />

## AI 활용 점검

> AI를 어떻게 활용했는지 적어주세요.

## 추가 참고 사항

> 리뷰어가 알아야 할 특이사항, 주의사항 등을 적어주세요.

## 스크린샷 / UI 변경 (선택)

> UI가 변경된 경우 스크린샷을 첨부해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 미션 배정 로직을 개선하여, 기존에 일부 기간의 미션만 존재할 때도 필요한 기간의 미션을 부분 배정하도록 수정
  * 동시 요청 발생 시 미션 배정 처리 개선

* **테스트**
  * 미션 배정 동작에 대한 포괄적인 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->