### PR TITLE
[fix] 출석 연속 복구 미작동 수정

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'pnpm'
@@ -51,7 +51,7 @@ jobs:
           onlyChanged: true
 
       - name: Comment PR
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: chromatic
           skip_unchanged: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,26 +55,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: "22"
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v5
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Cache pnpm dependencies
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -128,26 +116,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: "22"
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v5
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Cache pnpm dependencies
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -198,26 +174,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: "22"
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v5
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Cache pnpm dependencies
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -267,26 +231,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: "22"
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v5
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Cache pnpm dependencies
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -321,13 +273,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: "22"
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -354,13 +307,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: "22"
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -420,13 +374,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: "22"
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+          cache: "pnpm"
 
       - name: Client Security Audit
         id: client-audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
       packages-toss-shared: ${{ steps.filter.outputs.packages-toss-shared }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Detect changed paths
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -53,15 +53,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Get pnpm store directory
         shell: bash
@@ -69,7 +69,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Cache pnpm dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
@@ -126,15 +126,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Get pnpm store directory
         shell: bash
@@ -142,7 +142,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Cache pnpm dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
@@ -196,15 +196,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Get pnpm store directory
         shell: bash
@@ -212,7 +212,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Cache pnpm dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
@@ -265,15 +265,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Get pnpm store directory
         shell: bash
@@ -281,7 +281,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - name: Cache pnpm dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
@@ -319,15 +319,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -352,15 +352,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -418,15 +418,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Client Security Audit
         id: client-audit
@@ -451,7 +451,7 @@ jobs:
         continue-on-error: true
 
       - name: Post Security Audit Report
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           CLIENT_AUDIT: ${{ steps.client-audit.outputs.result }}
           SERVER_AUDIT: ${{ steps.server-audit.outputs.result }}

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Copy .env.redis file
         working-directory: ./infra/deploy/db
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Copy .env file
         working-directory: ./deploy

--- a/.github/workflows/deploy-toss-backend.yml
+++ b/.github/workflows/deploy-toss-backend.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Copy .env file
         working-directory: ./deploy-toss

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -13,15 +13,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -43,7 +43,7 @@ jobs:
 
       - name: Generate Lighthouse Report
         id: report
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         if: always()
         with:
           script: |
@@ -75,7 +75,7 @@ jobs:
             core.setOutput('body', body);
 
       - name: Comment PR
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         if: always()
         with:
           header: lighthouse

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -15,13 +15,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: "22"
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/client-toss/granite.config.ts
+++ b/client-toss/granite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "@apps-in-toss/web-framework/config";
 export default defineConfig({
   appName: "we-are-all-da-vinci",
   brand: {
-    displayName: "우리 모두 다빈치",
+    displayName: "똑같이 그려봐",
     primaryColor: "#0166FE",
     icon: "https://static.toss.im/appsintoss/23215/f7b34a41-2e40-405f-8323-35f7208b7998.png",
   },

--- a/client-toss/index.html
+++ b/client-toss/index.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     />
-    <title>우리모두다빈치앱인토스</title>
+    <title>똑같이 그려봐</title>
     <link rel="icon" type="image/png" href="/favicon.png" />
   </head>
   <body>

--- a/client-toss/src/entities/attendance/ui/AttendanceSummary.tsx
+++ b/client-toss/src/entities/attendance/ui/AttendanceSummary.tsx
@@ -27,7 +27,7 @@ const renderSubText = (
   if (maxTomorrow > 0) {
     return (
       <>
-        내일도 참여하면 최대 <PointHighlight>{maxTomorrow}원</PointHighlight>
+        내일도 참여하면 최소 <PointHighlight>{maxTomorrow}원</PointHighlight>
       </>
     );
   }
@@ -47,6 +47,8 @@ const AttendanceSummary = ({
   status,
   missionMaxPoint = 0,
 }: AttendanceSummaryProps) => {
+  // 끊김(복구 가능)이면 오늘이 1일차여도 "1일 연속 출석 중!"이 아니라 끊김 상태를 안내한다.
+  const isBroken = status?.recoverable === true && status.previousDay != null;
   const streakText = status ? `${status.cycleDay}` : "-";
 
   return (
@@ -55,18 +57,34 @@ const AttendanceSummary = ({
         aria-hidden
         className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-(--color-page) text-2xl leading-none"
       >
-        🔥
+        {isBroken ? "💔" : "🔥"}
       </span>
       <div>
-        <p className="leading-tight font-bold text-(--color-black)">
-          <span className="text-[22px] text-(--color-toss-blue)">
-            {streakText}일
-          </span>{" "}
-          <span className="text-base">연속 출석 중!</span>
-        </p>
-        <p className="mt-1 text-[13px] text-(--color-grey)">
-          {renderSubText(status, missionMaxPoint)}
-        </p>
+        {isBroken ? (
+          <>
+            <p className="leading-tight font-bold text-(--color-black)">
+              <span className="text-[22px] text-(--color-toss-blue)">
+                {status.previousDay}일
+              </span>{" "}
+              <span className="text-base">연속출석 중이에요</span>
+            </p>
+            <p className="mt-1 text-[13px] text-(--color-grey)">
+              오늘까지 이어갈 수 있어요
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="leading-tight font-bold text-(--color-black)">
+              <span className="text-[22px] text-(--color-toss-blue)">
+                {streakText}일
+              </span>{" "}
+              <span className="text-base">연속출석 중!</span>
+            </p>
+            <p className="mt-1 text-[13px] text-(--color-grey)">
+              {renderSubText(status, missionMaxPoint)}
+            </p>
+          </>
+        )}
       </div>
     </div>
   );

--- a/client-toss/src/entities/missionCard/ui/MissionSection.tsx
+++ b/client-toss/src/entities/missionCard/ui/MissionSection.tsx
@@ -31,7 +31,7 @@ const MissionSection = ({
         }
         right={
           rangeLabel ? (
-            <span className="pr-(--page-px) text-[13px] text-(--color-grey)">
+            <span className="shrink-0 pr-(--page-px) text-[13px] whitespace-nowrap text-(--color-grey)">
               {rangeLabel}
             </span>
           ) : undefined

--- a/client-toss/src/feature/attendanceRecovery/config/recoveryToast.ts
+++ b/client-toss/src/feature/attendanceRecovery/config/recoveryToast.ts
@@ -1,0 +1,22 @@
+/** 끊김 복구 토스트 노출 시간(ms). */
+export const ATTENDANCE_RECOVERY_TOAST_DURATION_MS = 2500;
+
+/** 복구 성공 안내. */
+export const ATTENDANCE_RECOVERY_SUCCESS_MESSAGE = "연속출석을 이어갔어요";
+
+/** "새롭게 시작하기"(복구 포기) 실패 안내. */
+export const ATTENDANCE_RECOVERY_DECLINE_FAIL_MESSAGE =
+  "잠시 후 다시 시도해주세요.";
+
+/** 복구(광고) 실패 사유별 안내 문구. */
+const RECOVERY_FAIL_MESSAGE = {
+  ad_not_ready: "광고를 불러오고 있어요. 잠시 후 다시 시도해주세요.",
+  not_watched: "광고 시청이 완료되지 않았어요. 다시 시도해주세요.",
+  error: "이어가기에 실패했어요. 잠시 후 다시 시도해주세요.",
+} as const;
+
+/** 복구 실패 사유 — 메시지 맵의 키이자 `useAttendanceRecovery` 반환 reason의 단일 소스. */
+export type RecoveryFailReason = keyof typeof RECOVERY_FAIL_MESSAGE;
+
+export const getRecoveryFailMessage = (reason: RecoveryFailReason): string =>
+  RECOVERY_FAIL_MESSAGE[reason];

--- a/client-toss/src/feature/attendanceRecovery/hooks/useAttendanceRecovery.test.ts
+++ b/client-toss/src/feature/attendanceRecovery/hooks/useAttendanceRecovery.test.ts
@@ -1,0 +1,129 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { serverTossApi } from "@/shared/api";
+import {
+  loadFullScreenAd,
+  showFullScreenAd,
+} from "@apps-in-toss/web-framework";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+import { useAttendanceRecovery } from "./useAttendanceRecovery";
+
+vi.mock("@/shared/api", () => ({
+  serverTossApi: {
+    recoverAttendance: vi.fn(),
+    declineAttendanceRecovery: vi.fn(),
+  },
+  getAnalyticsInstance: vi.fn().mockReturnValue(null),
+}));
+
+const mockedApi = serverTossApi as unknown as {
+  recoverAttendance: Mock;
+  declineAttendanceRecovery: Mock;
+};
+const mockLoad = loadFullScreenAd as unknown as Mock & {
+  isSupported: Mock;
+};
+const mockShow = showFullScreenAd as unknown as Mock;
+
+type Handlers = { onEvent?: (event: { type: string; data?: unknown }) => void };
+
+const RECOVERY_AD_GROUP = "ait.v2.live.932e847f2b0c499c";
+
+describe("출석 복구 훅", () => {
+  let loadHandlers: Handlers;
+  let showHandlers: Handlers;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoad.isSupported.mockReturnValue(true);
+    loadHandlers = {};
+    showHandlers = {};
+    mockLoad.mockImplementation((args: Handlers) => {
+      loadHandlers.onEvent = args.onEvent;
+      return vi.fn();
+    });
+    mockShow.mockImplementation((args: Handlers) => {
+      showHandlers.onEvent = args.onEvent;
+      return vi.fn();
+    });
+    mockedApi.recoverAttendance.mockResolvedValue({
+      cycleDay: 3,
+      rewardedDay: 3,
+    });
+    mockedApi.declineAttendanceRecovery.mockResolvedValue({
+      cycleDay: 1,
+      checkedToday: true,
+      recoverable: false,
+      previousDay: null,
+      tomorrowMaxPoint: 0,
+    });
+  });
+
+  const loadAd = () =>
+    act(() => {
+      loadHandlers.onEvent?.({ type: "loaded" });
+    });
+
+  it("보상 데이터 없이 userEarnedReward만 발생해도 시청을 인정하고 복구 API를 호출한다", async () => {
+    const { result } = renderHook(() => useAttendanceRecovery());
+    loadAd();
+
+    let outcome;
+    await act(async () => {
+      const pending = result.current.recover();
+      // 토스 애즈/AdMob이 data 없이 보상 이벤트를 내려주는 상황을 재현한다.
+      showHandlers.onEvent?.({ type: "impression" });
+      showHandlers.onEvent?.({ type: "userEarnedReward" });
+      showHandlers.onEvent?.({ type: "dismissed" });
+      outcome = await pending;
+    });
+
+    expect(outcome).toEqual({ ok: true });
+    expect(mockedApi.recoverAttendance).toHaveBeenCalledWith({
+      adGroupId: RECOVERY_AD_GROUP,
+    });
+  });
+
+  it("끝까지 보지 않아(userEarnedReward 미발생) dismissed만 오면 복구하지 않는다", async () => {
+    const { result } = renderHook(() => useAttendanceRecovery());
+    loadAd();
+
+    let outcome;
+    await act(async () => {
+      const pending = result.current.recover();
+      showHandlers.onEvent?.({ type: "impression" });
+      showHandlers.onEvent?.({ type: "dismissed" });
+      outcome = await pending;
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: "not_watched" });
+    expect(mockedApi.recoverAttendance).not.toHaveBeenCalled();
+  });
+
+  it("광고가 아직 로드되지 않았으면 ad_not_ready를 반환한다", async () => {
+    const { result } = renderHook(() => useAttendanceRecovery());
+    // loaded 이벤트를 보내지 않아 isAdLoaded=false 유지.
+
+    let outcome;
+    await act(async () => {
+      outcome = await result.current.recover();
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: "ad_not_ready" });
+    expect(mockShow).not.toHaveBeenCalled();
+    expect(mockedApi.recoverAttendance).not.toHaveBeenCalled();
+  });
+
+  it("새롭게 시작하기는 광고 없이 복구 대상을 비우는 API를 호출한다", async () => {
+    const { result } = renderHook(() => useAttendanceRecovery());
+
+    let ok;
+    await act(async () => {
+      ok = await result.current.decline();
+    });
+
+    expect(ok).toBe(true);
+    expect(mockedApi.declineAttendanceRecovery).toHaveBeenCalled();
+    expect(mockShow).not.toHaveBeenCalled();
+  });
+});

--- a/client-toss/src/feature/attendanceRecovery/hooks/useAttendanceRecovery.ts
+++ b/client-toss/src/feature/attendanceRecovery/hooks/useAttendanceRecovery.ts
@@ -3,12 +3,11 @@ import { serverTossApi } from "@/shared/api";
 import { AD_GROUP_IDS } from "@/shared/config";
 import { FUNNEL_EVENTS, getErrorMessage, trackClick } from "@/shared/lib";
 import { useCallback, useState } from "react";
+import type { RecoveryFailReason } from "../config/recoveryToast";
 
 const RECOVERY_AD_GROUP_ID = AD_GROUP_IDS.ATTENDANCE_RECOVERY;
 
-type RecoverResult =
-  | { ok: true }
-  | { ok: false; reason: "ad_not_ready" | "not_watched" | "error" };
+type RecoverResult = { ok: true } | { ok: false; reason: RecoveryFailReason };
 
 /**
  * 끊긴 연속 출석을 보상형 광고 완주로 복구하는 단일 훅.
@@ -40,12 +39,17 @@ export const useAttendanceRecovery = () => {
       // 보상형: userEarnedReward가 발생한 경우에만 resolve된다(끝까지 시청).
       await showAd();
     } catch (err) {
+      const adErrorReason = getErrorMessage(err);
       trackClick(FUNNEL_EVENTS.adRewardFailed, {
         ad_group_id: RECOVERY_AD_GROUP_ID,
-        reason: getErrorMessage(err),
+        reason: adErrorReason,
       });
       setIsRecovering(false);
-      return { ok: false, reason: "not_watched" };
+      // userEarnedReward 미발생(끝까지 안 봄)만 미시청으로, 그 외(failedToShow·SDK 에러)는 시스템 오류로.
+      return {
+        ok: false,
+        reason: adErrorReason === "reward_not_earned" ? "not_watched" : "error",
+      };
     }
 
     try {

--- a/client-toss/src/feature/attendanceRecovery/hooks/useAttendanceRecovery.ts
+++ b/client-toss/src/feature/attendanceRecovery/hooks/useAttendanceRecovery.ts
@@ -1,0 +1,80 @@
+import { useFullScreenAd } from "@/feature/playChance";
+import { serverTossApi } from "@/shared/api";
+import { AD_GROUP_IDS } from "@/shared/config";
+import { FUNNEL_EVENTS, getErrorMessage, trackClick } from "@/shared/lib";
+import { useCallback, useState } from "react";
+
+const RECOVERY_AD_GROUP_ID = AD_GROUP_IDS.ATTENDANCE_RECOVERY;
+
+type RecoverResult =
+  | { ok: true }
+  | { ok: false; reason: "ad_not_ready" | "not_watched" | "error" };
+
+/**
+ * 끊긴 연속 출석을 보상형 광고 완주로 복구하는 단일 훅.
+ * 끊김 결과 시트와 미션/대시보드 카드의 복구 버튼이 공유한다.
+ *
+ * - 광고 성공 판정은 `userEarnedReward` 발생 여부로만 한다(reward data 필드에 의존하지 않음).
+ *   서버 `recover()`는 `adGroupId`만 검증하므로 reward 페이로드를 보내지 않는다.
+ * - 결과는 `{ ok, reason }`으로 반환 → 호출부가 reason만 토스트로 매핑한다(useStartGame과 동일 패턴).
+ */
+export const useAttendanceRecovery = () => {
+  const { isAdLoaded, showAd, reloadAd } = useFullScreenAd(
+    RECOVERY_AD_GROUP_ID,
+    { rewarded: true },
+  );
+  const [isRecovering, setIsRecovering] = useState(false);
+
+  const recover = useCallback(async (): Promise<RecoverResult> => {
+    if (isRecovering) return { ok: false, reason: "error" };
+    if (!isAdLoaded) {
+      reloadAd();
+      return { ok: false, reason: "ad_not_ready" };
+    }
+
+    setIsRecovering(true);
+    trackClick(FUNNEL_EVENTS.adRewardAttempt, {
+      ad_group_id: RECOVERY_AD_GROUP_ID,
+    });
+    try {
+      // 보상형: userEarnedReward가 발생한 경우에만 resolve된다(끝까지 시청).
+      await showAd();
+    } catch (err) {
+      trackClick(FUNNEL_EVENTS.adRewardFailed, {
+        ad_group_id: RECOVERY_AD_GROUP_ID,
+        reason: getErrorMessage(err),
+      });
+      setIsRecovering(false);
+      return { ok: false, reason: "not_watched" };
+    }
+
+    try {
+      await serverTossApi.recoverAttendance({
+        adGroupId: RECOVERY_AD_GROUP_ID,
+      });
+      trackClick(FUNNEL_EVENTS.adRewardSuccess, {
+        ad_group_id: RECOVERY_AD_GROUP_ID,
+      });
+      return { ok: true };
+    } catch (err) {
+      trackClick(FUNNEL_EVENTS.adRewardFailed, {
+        ad_group_id: RECOVERY_AD_GROUP_ID,
+        reason: getErrorMessage(err),
+      });
+      return { ok: false, reason: "error" };
+    } finally {
+      setIsRecovering(false);
+    }
+  }, [isAdLoaded, isRecovering, reloadAd, showAd]);
+
+  const decline = useCallback(async (): Promise<boolean> => {
+    try {
+      await serverTossApi.declineAttendanceRecovery();
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
+
+  return { recover, decline, isRecovering, isAdLoaded, reloadAd };
+};

--- a/client-toss/src/feature/attendanceRecovery/index.ts
+++ b/client-toss/src/feature/attendanceRecovery/index.ts
@@ -1,2 +1,8 @@
+export {
+  ATTENDANCE_RECOVERY_DECLINE_FAIL_MESSAGE,
+  ATTENDANCE_RECOVERY_SUCCESS_MESSAGE,
+  ATTENDANCE_RECOVERY_TOAST_DURATION_MS,
+  getRecoveryFailMessage,
+} from "./config/recoveryToast";
 export { useAttendanceRecovery } from "./hooks/useAttendanceRecovery";
 export { default as AttendanceRecoverButton } from "./ui/AttendanceRecoverButton";

--- a/client-toss/src/feature/attendanceRecovery/index.ts
+++ b/client-toss/src/feature/attendanceRecovery/index.ts
@@ -1,0 +1,2 @@
+export { useAttendanceRecovery } from "./hooks/useAttendanceRecovery";
+export { default as AttendanceRecoverButton } from "./ui/AttendanceRecoverButton";

--- a/client-toss/src/feature/attendanceRecovery/ui/AttendanceRecoverButton.tsx
+++ b/client-toss/src/feature/attendanceRecovery/ui/AttendanceRecoverButton.tsx
@@ -1,0 +1,89 @@
+import { useToast } from "@/shared/lib";
+import { Button, Toast } from "@toss/tds-mobile";
+import { useState } from "react";
+import { useAttendanceRecovery } from "../hooks/useAttendanceRecovery";
+
+const TOAST_DURATION_MS = 2500;
+
+interface AttendanceRecoverButtonProps {
+  /** 복구/포기로 출석 현황이 바뀐 직후 호출 — 현황을 재조회해 카드를 갱신한다. */
+  onResolved: () => void;
+}
+
+/**
+ * 끊김 카드의 액션 묶음 — "광고 보고 이어가기"(복구)와 "새롭게 시작하기"(포기).
+ * 끊김 감지 당일(`status.recoverable`)에만 미션/대시보드 카드가 렌더한다.
+ */
+const AttendanceRecoverButton = ({
+  onResolved,
+}: AttendanceRecoverButtonProps) => {
+  const toast = useToast();
+  const { recover, decline, isRecovering } = useAttendanceRecovery();
+  const [isDeclining, setIsDeclining] = useState(false);
+
+  const handleRecover = async () => {
+    const result = await recover();
+    if (result.ok) {
+      onResolved();
+      toast.show("연속출석을 이어갔어요");
+      return;
+    }
+    if (result.reason === "ad_not_ready") {
+      toast.show("광고를 불러오고 있어요. 잠시 후 다시 시도해주세요.");
+    } else if (result.reason === "not_watched") {
+      toast.show("광고 시청이 완료되지 않았어요. 다시 시도해주세요.");
+    } else {
+      toast.show("이어가기에 실패했어요. 잠시 후 다시 시도해주세요.");
+    }
+  };
+
+  const handleDecline = async () => {
+    if (isDeclining) return;
+    setIsDeclining(true);
+    const ok = await decline();
+    setIsDeclining(false);
+    if (ok) onResolved();
+    else toast.show("잠시 후 다시 시도해주세요.");
+  };
+
+  return (
+    <>
+      <div className="flex gap-2">
+        <div className="flex-1">
+          <Button
+            variant="weak"
+            display="block"
+            size="small"
+            loading={isDeclining}
+            disabled={isRecovering || isDeclining}
+            onClick={handleDecline}
+          >
+            새롭게 시작하기
+          </Button>
+        </div>
+        <div className="flex-1">
+          <Button
+            color="primary"
+            display="block"
+            size="small"
+            loading={isRecovering}
+            disabled={isRecovering || isDeclining}
+            onClick={handleRecover}
+          >
+            광고 보고 이어가기
+          </Button>
+        </div>
+      </div>
+
+      <Toast
+        position="top"
+        open={toast.open}
+        text={toast.text}
+        duration={TOAST_DURATION_MS}
+        onClose={toast.close}
+      />
+    </>
+  );
+};
+
+export default AttendanceRecoverButton;

--- a/client-toss/src/feature/attendanceRecovery/ui/AttendanceRecoverButton.tsx
+++ b/client-toss/src/feature/attendanceRecovery/ui/AttendanceRecoverButton.tsx
@@ -1,9 +1,13 @@
 import { useToast } from "@/shared/lib";
 import { Button, Toast } from "@toss/tds-mobile";
 import { useState } from "react";
+import {
+  ATTENDANCE_RECOVERY_DECLINE_FAIL_MESSAGE,
+  ATTENDANCE_RECOVERY_SUCCESS_MESSAGE,
+  ATTENDANCE_RECOVERY_TOAST_DURATION_MS,
+  getRecoveryFailMessage,
+} from "../config/recoveryToast";
 import { useAttendanceRecovery } from "../hooks/useAttendanceRecovery";
-
-const TOAST_DURATION_MS = 2500;
 
 interface AttendanceRecoverButtonProps {
   /** 복구/포기로 출석 현황이 바뀐 직후 호출 — 현황을 재조회해 카드를 갱신한다. */
@@ -25,16 +29,10 @@ const AttendanceRecoverButton = ({
     const result = await recover();
     if (result.ok) {
       onResolved();
-      toast.show("연속출석을 이어갔어요");
+      toast.show(ATTENDANCE_RECOVERY_SUCCESS_MESSAGE);
       return;
     }
-    if (result.reason === "ad_not_ready") {
-      toast.show("광고를 불러오고 있어요. 잠시 후 다시 시도해주세요.");
-    } else if (result.reason === "not_watched") {
-      toast.show("광고 시청이 완료되지 않았어요. 다시 시도해주세요.");
-    } else {
-      toast.show("이어가기에 실패했어요. 잠시 후 다시 시도해주세요.");
-    }
+    toast.show(getRecoveryFailMessage(result.reason));
   };
 
   const handleDecline = async () => {
@@ -43,7 +41,7 @@ const AttendanceRecoverButton = ({
     const ok = await decline();
     setIsDeclining(false);
     if (ok) onResolved();
-    else toast.show("잠시 후 다시 시도해주세요.");
+    else toast.show(ATTENDANCE_RECOVERY_DECLINE_FAIL_MESSAGE);
   };
 
   return (
@@ -79,7 +77,7 @@ const AttendanceRecoverButton = ({
         position="top"
         open={toast.open}
         text={toast.text}
-        duration={TOAST_DURATION_MS}
+        duration={ATTENDANCE_RECOVERY_TOAST_DURATION_MS}
         onClose={toast.close}
       />
     </>

--- a/client-toss/src/feature/playChance/hooks/useFullScreenAd.ts
+++ b/client-toss/src/feature/playChance/hooks/useFullScreenAd.ts
@@ -97,6 +97,7 @@ export const useFullScreenAd = (
         }
 
         let wasShown = false;
+        let earnedReward = false;
         let reward: AdRewardData | undefined;
         let done = false;
 
@@ -112,15 +113,18 @@ export const useFullScreenAd = (
             }
             // 광고가 실제 화면에 렌더링된 시점(수익 발생 시점). impression 없이 종료된 경우 충전 트리거하지 않는다.
             if (event.type === "impression") wasShown = true;
-            // 보상형: 사용자가 시청을 완료해 리워드를 획득한 시점. 이 데이터로만 보상 인정.
-            if (event.type === "userEarnedReward") reward = event.data;
+            // 보상형: 사용자가 시청을 완료해 리워드를 획득한 시점.
+            if (event.type === "userEarnedReward") {
+              earnedReward = true;
+              reward = event.data;
+            }
             if (event.type === "dismissed") {
               if (done) return;
               done = true;
               reloadAd();
-              // 보상형은 userEarnedReward가 있어야만 성공으로 인정한다.
+              // 보상형은 userEarnedReward가 발생한 경우에만 성공으로 인정한다.
               if (rewarded) {
-                if (reward) resolve(reward);
+                if (earnedReward) resolve(reward);
                 else reject(new Error("reward_not_earned"));
                 return;
               }

--- a/client-toss/src/feature/share/config/shareMessage.ts
+++ b/client-toss/src/feature/share/config/shareMessage.ts
@@ -4,6 +4,6 @@ const buildShareMessageWithRanking = (
   tossLink: string,
 ): string =>
   `제 점수는 ${score}점이에요! (랭킹 ${rank}위) \n같이 도전해봐요!\n${tossLink}
-  \n기억하고 그려서 두뇌를 깨우는 앱 \n우리 모두 다빈치`;
+  \n기억하고 그려서 두뇌를 깨우는 앱 \n똑같이 그려봐`;
 
 export { buildShareMessageWithRanking };

--- a/client-toss/src/shared/api/serverToss.ts
+++ b/client-toss/src/shared/api/serverToss.ts
@@ -321,6 +321,11 @@ export const serverTossApi = {
       await request<unknown>("POST", "/attendance/recover", { sdkPayload }),
     ),
 
+  declineAttendanceRecovery: async () =>
+    AttendanceStatusResponseSchema.parse(
+      await request<unknown>("POST", "/attendance/decline"),
+    ),
+
   getPointSummary: async (options?: RequestOptions) =>
     PointSummaryResponseSchema.parse(
       await request<unknown>("GET", "/points/me", undefined, options),

--- a/client-toss/src/views/dashboard/ui/AttendanceResultSheet.test.tsx
+++ b/client-toss/src/views/dashboard/ui/AttendanceResultSheet.test.tsx
@@ -6,7 +6,10 @@ import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import AttendanceResultSheet from "./AttendanceResultSheet";
 
 vi.mock("@/shared/api", () => ({
-  serverTossApi: { recoverAttendance: vi.fn() },
+  serverTossApi: {
+    recoverAttendance: vi.fn(),
+    declineAttendanceRecovery: vi.fn(),
+  },
   getAnalyticsInstance: vi.fn().mockReturnValue(null),
 }));
 
@@ -58,11 +61,11 @@ describe("출석 결과 시트", () => {
       />,
     );
 
-    expect(screen.getByText(/3일 연속 출석/)).toBeInTheDocument();
+    expect(screen.getByText(/3일 연속출석/)).toBeInTheDocument();
     expect(screen.getByText(/적립/)).toBeInTheDocument();
   });
 
-  it("끊긴 경우 광고 이어가기와 처음부터 시작을 함께 보여준다", () => {
+  it("끊긴 경우 광고 이어가기와 새롭게 시작하기를 함께 보여준다", () => {
     render(
       <AttendanceResultSheet
         result={broken}
@@ -71,12 +74,12 @@ describe("출석 결과 시트", () => {
       />,
     );
 
-    expect(screen.getByText("연속 출석이 끊겼어요!")).toBeInTheDocument();
+    expect(screen.getByText("연속출석이 끊겼어요!")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "광고 보고 이어가기" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "처음부터 시작" }),
+      screen.getByRole("button", { name: "새롭게 시작하기" }),
     ).toBeInTheDocument();
   });
 
@@ -97,10 +100,9 @@ describe("출석 결과 시트", () => {
 
     await waitFor(() => {
       expect(mockShowAd).toHaveBeenCalled();
+      // 서버 recover()는 adGroupId만 검증하므로 reward 페이로드는 보내지 않는다.
       expect(mockedApi.recoverAttendance).toHaveBeenCalledWith({
         adGroupId: "ait.v2.live.932e847f2b0c499c",
-        unitType: "point",
-        unitAmount: 1,
       });
       expect(onRecovered).toHaveBeenCalled();
       expect(onClose).toHaveBeenCalled();

--- a/client-toss/src/views/dashboard/ui/AttendanceResultSheet.test.tsx
+++ b/client-toss/src/views/dashboard/ui/AttendanceResultSheet.test.tsx
@@ -25,7 +25,10 @@ vi.mock("@/feature/playChance/hooks/useFullScreenAd", () => ({
   }),
 }));
 
-const mockedApi = serverTossApi as unknown as { recoverAttendance: Mock };
+const mockedApi = serverTossApi as unknown as {
+  recoverAttendance: Mock;
+  declineAttendanceRecovery: Mock;
+};
 
 const continued: AttendanceCheckInResponse = {
   status: "continued",
@@ -49,6 +52,13 @@ describe("출석 결과 시트", () => {
     mockedApi.recoverAttendance.mockResolvedValue({
       cycleDay: 3,
       rewardedDay: 3,
+    });
+    mockedApi.declineAttendanceRecovery.mockResolvedValue({
+      cycleDay: 1,
+      checkedToday: true,
+      recoverable: false,
+      previousDay: null,
+      tomorrowMaxPoint: 0,
     });
   });
 
@@ -104,6 +114,29 @@ describe("출석 결과 시트", () => {
       expect(mockedApi.recoverAttendance).toHaveBeenCalledWith({
         adGroupId: "ait.v2.live.932e847f2b0c499c",
       });
+      expect(onRecovered).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("새롭게 시작하기를 누르면 복구 포기 API를 호출하고 시트를 닫는다", async () => {
+    const onClose = vi.fn();
+    const onRecovered = vi.fn();
+    render(
+      <AttendanceResultSheet
+        result={broken}
+        onClose={onClose}
+        onRecovered={onRecovered}
+      />,
+    );
+
+    await act(async () => {
+      screen.getByRole("button", { name: "새롭게 시작하기" }).click();
+    });
+
+    await waitFor(() => {
+      expect(mockedApi.declineAttendanceRecovery).toHaveBeenCalled();
+      expect(mockShowAd).not.toHaveBeenCalled();
       expect(onRecovered).toHaveBeenCalled();
       expect(onClose).toHaveBeenCalled();
     });

--- a/client-toss/src/views/dashboard/ui/AttendanceResultSheet.tsx
+++ b/client-toss/src/views/dashboard/ui/AttendanceResultSheet.tsx
@@ -1,7 +1,5 @@
 import { AttendanceProgress } from "@/entities/attendance";
-import { useFullScreenAd } from "@/feature/playChance";
-import { serverTossApi } from "@/shared/api";
-import { AD_GROUP_IDS } from "@/shared/config";
+import { useAttendanceRecovery } from "@/feature/attendanceRecovery";
 import { useToast } from "@/shared/lib";
 import { ATTENDANCE_REWARD_POINT } from "@toss/shared";
 import type { AttendanceCheckInResponse } from "@toss/shared";
@@ -19,7 +17,7 @@ interface AttendanceResultSheetProps {
 /**
  * 출석 체크 결과를 안내하는 바텀시트.
  * - 연속/첫 출석: 연속 일수 + (마일스톤 시) 적립 안내.
- * - 끊김: 끊긴 연속을 보여주고 보상형 광고로 이어가거나 처음부터 시작한다.
+ * - 끊김: 끊긴 연속을 보여주고 보상형 광고로 이어가거나 새롭게 시작한다(복구 포기).
  */
 const AttendanceResultSheet = ({
   result,
@@ -27,41 +25,45 @@ const AttendanceResultSheet = ({
   onRecovered,
 }: AttendanceResultSheetProps) => {
   const toast = useToast();
-  const { isAdLoaded, showAd, reloadAd } = useFullScreenAd(
-    AD_GROUP_IDS.ATTENDANCE_RECOVERY,
-    { rewarded: true },
-  );
-  const [isRecovering, setIsRecovering] = useState(false);
+  const { recover, decline, isRecovering } = useAttendanceRecovery();
+  const [isDeclining, setIsDeclining] = useState(false);
 
   const isBroken = result?.status === "reset_recoverable";
 
-  const handleRecover = async () => {
-    if (isRecovering) return;
-    if (!isAdLoaded) {
-      reloadAd();
-      toast.show("광고를 불러오고 있어요. 잠시 후 다시 시도해주세요.");
-      return;
-    }
+  let headerText = "";
+  if (result != null) {
+    headerText = isBroken
+      ? "연속출석이 끊겼어요!"
+      : `🔥 ${result.cycleDay}일 연속출석!`;
+  }
 
-    setIsRecovering(true);
-    try {
-      const reward = await showAd();
-      if (!reward?.unitType || reward.unitAmount == null) {
-        toast.show("광고 시청이 완료되지 않았어요. 다시 시도해주세요.");
-        return;
-      }
-      await serverTossApi.recoverAttendance({
-        adGroupId: AD_GROUP_IDS.ATTENDANCE_RECOVERY,
-        unitType: reward.unitType,
-        unitAmount: reward.unitAmount,
-      });
+  const handleRecover = async () => {
+    const outcome = await recover();
+    if (outcome.ok) {
       onRecovered();
       onClose();
-      toast.show("연속 출석을 이어갔어요");
-    } catch {
+      toast.show("연속출석을 이어갔어요");
+      return;
+    }
+    if (outcome.reason === "ad_not_ready") {
+      toast.show("광고를 불러오고 있어요. 잠시 후 다시 시도해주세요.");
+    } else if (outcome.reason === "not_watched") {
+      toast.show("광고 시청이 완료되지 않았어요. 다시 시도해주세요.");
+    } else {
       toast.show("이어가기에 실패했어요. 잠시 후 다시 시도해주세요.");
-    } finally {
-      setIsRecovering(false);
+    }
+  };
+
+  const handleDecline = async () => {
+    if (isDeclining) return;
+    setIsDeclining(true);
+    const ok = await decline();
+    setIsDeclining(false);
+    if (ok) {
+      onRecovered();
+      onClose();
+    } else {
+      toast.show("잠시 후 다시 시도해주세요.");
     }
   };
 
@@ -75,19 +77,14 @@ const AttendanceResultSheet = ({
       <BottomSheet
         open={result != null}
         onClose={onClose}
-        header={<BottomSheet.Header>출석 체크</BottomSheet.Header>}
+        header={<BottomSheet.Header>{headerText}</BottomSheet.Header>}
       >
         {result &&
           (isBroken ? (
             <div className="flex flex-col gap-5 px-(--page-px) pt-1 pb-[env(safe-area-inset-bottom)]">
-              <div>
-                <p className="text-lg font-bold text-(--color-black)">
-                  연속 출석이 끊겼어요!
-                </p>
-                <p className="mt-1 text-[13px] text-(--color-grey)">
-                  {result.previousDay}일 연속 출석 중이었어요
-                </p>
-              </div>
+              <p className="text-[13px] text-(--color-grey)">
+                {result.previousDay}일 연속출석 중이었어요
+              </p>
               <AttendanceProgress
                 cycleDay={result.cycleDay}
                 recoverableDay={result.previousDay}
@@ -97,25 +94,23 @@ const AttendanceResultSheet = ({
                   color="primary"
                   display="block"
                   loading={isRecovering}
-                  disabled={isRecovering}
+                  disabled={isRecovering || isDeclining}
                   onClick={handleRecover}
                 >
                   광고 보고 이어가기
                 </Button>
                 <button
                   type="button"
-                  onClick={onClose}
+                  onClick={handleDecline}
+                  disabled={isRecovering || isDeclining}
                   className="py-1 text-[13px] font-medium text-(--color-grey)"
                 >
-                  처음부터 시작
+                  새롭게 시작하기
                 </button>
               </div>
             </div>
           ) : (
             <div className="flex flex-col gap-5 px-(--page-px) pt-1 pb-[env(safe-area-inset-bottom)]">
-              <p className="text-lg font-bold text-(--color-black)">
-                🔥 {result.cycleDay}일 연속 출석!
-              </p>
               <AttendanceProgress cycleDay={result.cycleDay} />
               {rewardNote && (
                 <p className="text-[13px] font-medium text-(--color-toss-blue)">

--- a/client-toss/src/views/dashboard/ui/AttendanceResultSheet.tsx
+++ b/client-toss/src/views/dashboard/ui/AttendanceResultSheet.tsx
@@ -1,12 +1,16 @@
 import { AttendanceProgress } from "@/entities/attendance";
-import { useAttendanceRecovery } from "@/feature/attendanceRecovery";
+import {
+  ATTENDANCE_RECOVERY_DECLINE_FAIL_MESSAGE,
+  ATTENDANCE_RECOVERY_SUCCESS_MESSAGE,
+  ATTENDANCE_RECOVERY_TOAST_DURATION_MS,
+  getRecoveryFailMessage,
+  useAttendanceRecovery,
+} from "@/feature/attendanceRecovery";
 import { useToast } from "@/shared/lib";
 import { ATTENDANCE_REWARD_POINT } from "@toss/shared";
 import type { AttendanceCheckInResponse } from "@toss/shared";
 import { BottomSheet, Button, Toast } from "@toss/tds-mobile";
 import { useState } from "react";
-
-const TOAST_DURATION_MS = 2500;
 
 interface AttendanceResultSheetProps {
   result: AttendanceCheckInResponse | null;
@@ -42,16 +46,10 @@ const AttendanceResultSheet = ({
     if (outcome.ok) {
       onRecovered();
       onClose();
-      toast.show("연속출석을 이어갔어요");
+      toast.show(ATTENDANCE_RECOVERY_SUCCESS_MESSAGE);
       return;
     }
-    if (outcome.reason === "ad_not_ready") {
-      toast.show("광고를 불러오고 있어요. 잠시 후 다시 시도해주세요.");
-    } else if (outcome.reason === "not_watched") {
-      toast.show("광고 시청이 완료되지 않았어요. 다시 시도해주세요.");
-    } else {
-      toast.show("이어가기에 실패했어요. 잠시 후 다시 시도해주세요.");
-    }
+    toast.show(getRecoveryFailMessage(outcome.reason));
   };
 
   const handleDecline = async () => {
@@ -63,7 +61,7 @@ const AttendanceResultSheet = ({
       onRecovered();
       onClose();
     } else {
-      toast.show("잠시 후 다시 시도해주세요.");
+      toast.show(ATTENDANCE_RECOVERY_DECLINE_FAIL_MESSAGE);
     }
   };
 
@@ -128,7 +126,7 @@ const AttendanceResultSheet = ({
         position="top"
         open={toast.open}
         text={toast.text}
-        duration={TOAST_DURATION_MS}
+        duration={ATTENDANCE_RECOVERY_TOAST_DURATION_MS}
         onClose={toast.close}
       />
     </>

--- a/client-toss/src/views/dashboard/ui/DashboardView.tsx
+++ b/client-toss/src/views/dashboard/ui/DashboardView.tsx
@@ -182,6 +182,7 @@ const DashboardView = () => {
             status={attendanceStatus ?? undefined}
             pointSummary={pointSummary ?? undefined}
             missionMaxPoint={missionMaxPoint}
+            onRecovered={refreshAttendance}
           />
           <ChallengeCard
             cta={cta}
@@ -212,7 +213,7 @@ const DashboardView = () => {
       />
 
       <ExitDialog
-        title="우리 모두 다빈치를 종료할까요?"
+        title="똑같이 그려봐를 종료할까요?"
         confirmLabel="종료하기"
         cancelLabel="계속 둘러보기"
       />

--- a/client-toss/src/views/dashboard/ui/StreakStatsCard.test.tsx
+++ b/client-toss/src/views/dashboard/ui/StreakStatsCard.test.tsx
@@ -37,11 +37,11 @@ const baseStatus: AttendanceStatusResponse = {
 const pointSummary: PointSummaryResponse = { totalPoints: 30, todayPoints: 5 };
 
 describe("연속 출석 통계 카드", () => {
-  it("출석 마일스톤 + 미션 포인트를 합쳐 내일 최대 포인트를 보여준다", () => {
+  it("출석 마일스톤 + 미션 포인트를 합쳐 내일 받을 포인트를 보여준다", () => {
     renderCard(baseStatus, pointSummary, 4);
 
     // 출석 5원 + 미션 4원 = 9원 (강조 span으로 분리 렌더)
-    expect(screen.getByText(/내일도 참여하면 최대/)).toBeInTheDocument();
+    expect(screen.getByText(/내일도 참여하면 최소/)).toBeInTheDocument();
     expect(screen.getByText("9원")).toBeInTheDocument();
     expect(screen.getByText("2일")).toBeInTheDocument();
   });
@@ -69,5 +69,32 @@ describe("연속 출석 통계 카드", () => {
     expect(
       screen.getByText("매일 출석하고 토스포인트를 받아요"),
     ).toBeInTheDocument();
+  });
+
+  it("끊김 복구가 가능하면 광고 이어가기 버튼을 보여준다", () => {
+    render(
+      <MemoryRouter>
+        <StreakStatsCard
+          status={{ ...baseStatus, recoverable: true, previousDay: 1 }}
+          onRecovered={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "광고 보고 이어가기" }),
+    ).toBeInTheDocument();
+  });
+
+  it("복구 불가 상태면 광고 이어가기 버튼을 보여주지 않는다", () => {
+    render(
+      <MemoryRouter>
+        <StreakStatsCard status={baseStatus} onRecovered={vi.fn()} />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "광고 보고 이어가기" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/client-toss/src/views/dashboard/ui/StreakStatsCard.tsx
+++ b/client-toss/src/views/dashboard/ui/StreakStatsCard.tsx
@@ -1,4 +1,5 @@
 import { AttendanceSummary } from "@/entities/attendance";
+import { AttendanceRecoverButton } from "@/feature/attendanceRecovery";
 import { useMyRanking } from "@/entities/ranking";
 import type {
   AttendanceStatusResponse,
@@ -28,12 +29,15 @@ interface StreakStatsCardProps {
   /** 포인트는 출석과 분리된 리소스(/points/me) — 별도 prop으로 받는다. */
   pointSummary?: PointSummaryResponse;
   missionMaxPoint?: number;
+  /** 끊김 복구 성공 직후 호출 — 출석 현황·포인트를 재조회한다. */
+  onRecovered?: () => void;
 }
 
 const StreakStatsCard = ({
   status,
   pointSummary,
   missionMaxPoint = 0,
+  onRecovered,
 }: StreakStatsCardProps) => {
   const navigate = useNavigate();
   const { myRanking } = useMyRanking();
@@ -59,6 +63,12 @@ const StreakStatsCard = ({
           </span>
         </button>
       </div>
+
+      {status?.recoverable && onRecovered && (
+        <div className="mt-4">
+          <AttendanceRecoverButton onResolved={onRecovered} />
+        </div>
+      )}
 
       <div className="mt-5 flex items-stretch rounded-(--radius-inner) bg-(--color-page) py-4">
         <StatItem label="누적 토스포인트" value={totalText} />

--- a/client-toss/src/views/dashboard/ui/TodayDavinciCard.test.tsx
+++ b/client-toss/src/views/dashboard/ui/TodayDavinciCard.test.tsx
@@ -18,7 +18,7 @@ const samplePodium: PodiumResponse["podium"] = [
   { nickname: "피카소", score: 66 },
 ];
 
-describe("오늘의 다빈치 카드", () => {
+describe("기억력 TOP3 카드", () => {
   it("시상대 top3를 점수와 함께 보여준다", () => {
     renderCard(samplePodium);
 
@@ -31,7 +31,7 @@ describe("오늘의 다빈치 카드", () => {
   it("podium이 빈 배열이면 안내 문구를 보여준다", () => {
     renderCard([]);
 
-    expect(screen.getByText("아직 오늘의 다빈치가 없어요")).toBeInTheDocument();
+    expect(screen.getByText("아직 오늘의 기록이 없어요")).toBeInTheDocument();
   });
 
   it("podium이 undefined면 로딩 상태로 항목·안내를 노출하지 않는다", () => {
@@ -39,7 +39,7 @@ describe("오늘의 다빈치 카드", () => {
 
     expect(screen.queryByText("다빈치")).not.toBeInTheDocument();
     expect(
-      screen.queryByText("아직 오늘의 다빈치가 없어요"),
+      screen.queryByText("아직 오늘의 기록이 없어요"),
     ).not.toBeInTheDocument();
   });
 

--- a/client-toss/src/views/dashboard/ui/TodayDavinciCard.tsx
+++ b/client-toss/src/views/dashboard/ui/TodayDavinciCard.tsx
@@ -56,7 +56,7 @@ const TodayDavinciCard = ({ podium, myRank }: TodayDavinciCardProps) => {
         className="flex w-full items-baseline justify-between"
       >
         <h2 className="text-base font-bold text-(--color-black)">
-          오늘의 다빈치
+          기억력 TOP3
         </h2>
         <span className="text-[13px] font-medium text-(--color-grey)">
           랭킹 top100 ›
@@ -78,7 +78,7 @@ const TodayDavinciCard = ({ podium, myRank }: TodayDavinciCardProps) => {
           ))
         ) : (
           <p className="py-6 text-center text-sm text-(--color-grey)">
-            아직 오늘의 다빈치가 없어요
+            아직 오늘의 기록이 없어요
           </p>
         )}
       </div>

--- a/client-toss/src/views/login/ui/LoginView.tsx
+++ b/client-toss/src/views/login/ui/LoginView.tsx
@@ -17,7 +17,7 @@ const LoginView = () => {
             <Top.UpperAssetContent
               content={
                 <img
-                  alt="우리 모두 다빈치"
+                  alt="똑같이 그려봐"
                   src={logoImg}
                   className="h-19 w-19 rounded-[14px]"
                 />
@@ -26,7 +26,7 @@ const LoginView = () => {
           }
           title={
             <Top.TitleParagraph size={28}>
-              우리 모두 다빈치에서
+              똑같이 그려봐에서
               <br />
               토스로 로그인할까요?
             </Top.TitleParagraph>

--- a/client-toss/src/views/mission/ui/MissionView.tsx
+++ b/client-toss/src/views/mission/ui/MissionView.tsx
@@ -3,6 +3,7 @@ import {
   AttendanceSummary,
   useAttendanceStatus,
 } from "@/entities/attendance";
+import { AttendanceRecoverButton } from "@/feature/attendanceRecovery";
 import {
   getDailyMissionRangeLabel,
   getWeeklyMissionRangeLabel,
@@ -22,7 +23,8 @@ import { useEffect } from "react";
 const MissionView = () => {
   const { dailyMissions, weeklyMissions, tutorialCategories, isLoading } =
     useMyMissions();
-  const { status: attendanceStatus } = useAttendanceStatus();
+  const { status: attendanceStatus, refetch: refetchAttendance } =
+    useAttendanceStatus();
 
   useEffect(() => {
     trackScreen(FUNNEL_EVENTS.missionView);
@@ -65,13 +67,18 @@ const MissionView = () => {
               />
             </div>
             <p className="mt-3 text-[13px] text-(--color-grey)">
-              {ATTENDANCE_REWARD_DAYS.map((day) => `${day}일`).join("·")} 연속
-              출석하면{" "}
+              {ATTENDANCE_REWARD_DAYS.map((day) => `${day}일`).join("·")}{" "}
+              연속출석하면{" "}
               <span className="font-bold text-(--color-toss-blue)">
                 {ATTENDANCE_REWARD_POINT}원
               </span>
               을 추가로 받아요
             </p>
+            {attendanceStatus.recoverable && (
+              <div className="mt-4">
+                <AttendanceRecoverButton onResolved={refetchAttendance} />
+              </div>
+            )}
           </section>
         )}
 

--- a/server-toss/src/modules/attendance/attendance.controller.ts
+++ b/server-toss/src/modules/attendance/attendance.controller.ts
@@ -144,4 +144,18 @@ export class AttendanceController {
   ): Promise<AttendanceRecoverResponse> {
     return this.attendanceService.recover(user.userKey, body.sdkPayload);
   }
+
+  @Post("decline")
+  @HttpCode(200)
+  @ApiOperation({ summary: "복구를 포기하고 끊긴 채로 새로 시작" })
+  @ApiOkResponse({
+    description: "복구 대상을 비운 출석 현황",
+    schema: AttendanceStatusSchema,
+  })
+  @ApiUnauthorizedResponse({ description: "인증이 필요해요." })
+  declineRecovery(
+    @CurrentUser() user: CurrentUserPayload,
+  ): Promise<AttendanceStatusResponse> {
+    return this.attendanceService.declineRecovery(user.userKey);
+  }
 }

--- a/server-toss/src/modules/attendance/attendance.service.spec.ts
+++ b/server-toss/src/modules/attendance/attendance.service.spec.ts
@@ -252,6 +252,59 @@ describe("출석 서비스", () => {
         service.recover(1234, { adGroupId: RECOVERY_AD_GROUP }),
       ).rejects.toThrow(ForbiddenException);
     });
+
+    it("끊김 감지 당일이 지났으면(오늘 체크인 기록 아님) ForbiddenException으로 만료된다", async () => {
+      const attendance = {
+        userKey: 1234,
+        cycleDay: 1,
+        lastCheckedDate: YESTERDAY_START,
+        recoverableDay: 2,
+      };
+      const { em } = buildEm(attendance);
+      const { service } = buildService(em);
+
+      await expect(
+        service.recover(1234, { adGroupId: RECOVERY_AD_GROUP }),
+      ).rejects.toThrow(ForbiddenException);
+      expect(attendance.cycleDay).toBe(1);
+      expect(attendance.recoverableDay).toBe(2);
+    });
+  });
+
+  describe("복구 포기(새롭게 시작)", () => {
+    it("cycleDay는 그대로 두고 복구 대상만 비워 recoverable=false 현황을 반환한다", async () => {
+      const attendance = {
+        userKey: 1234,
+        cycleDay: 1,
+        lastCheckedDate: TODAY_START,
+        recoverableDay: 2,
+      };
+      const { em } = buildEm(attendance);
+      const { service } = buildService(em);
+
+      const result = await service.declineRecovery(1234);
+
+      expect(attendance.recoverableDay).toBeNull();
+      expect(attendance.cycleDay).toBe(1);
+      expect(result.recoverable).toBe(false);
+      expect(result.previousDay).toBeNull();
+    });
+
+    it("복구 대상이 없으면 아무것도 비우지 않고 현황만 반환한다(멱등)", async () => {
+      const attendance = {
+        userKey: 1234,
+        cycleDay: 3,
+        lastCheckedDate: TODAY_START,
+        recoverableDay: null,
+      };
+      const { em } = buildEm(attendance);
+      const { service } = buildService(em);
+
+      const result = await service.declineRecovery(1234);
+
+      expect(em.flush).not.toHaveBeenCalled();
+      expect(result.cycleDay).toBe(3);
+    });
   });
 
   describe("현황 조회", () => {
@@ -284,6 +337,37 @@ describe("출석 서비스", () => {
       expect(result.cycleDay).toBe(2);
       expect(result.checkedToday).toBe(true);
       expect(result.tomorrowMaxPoint).toBe(5);
+    });
+
+    it("끊김을 감지한 당일에는 recoverable=true와 직전 위치를 노출한다", async () => {
+      const { em } = buildEm({
+        userKey: 1234,
+        cycleDay: 1,
+        lastCheckedDate: TODAY_START,
+        recoverableDay: 2,
+      });
+      const { service } = buildService(em);
+
+      const result = await service.getStatus(1234);
+
+      expect(result.recoverable).toBe(true);
+      expect(result.previousDay).toBe(2);
+    });
+
+    it("당일이 지나면(오늘 체크인 기록 아님) recoverableDay가 남아 있어도 만료돼 recoverable=false다", async () => {
+      const { em } = buildEm({
+        userKey: 1234,
+        cycleDay: 1,
+        lastCheckedDate: YESTERDAY_START,
+        recoverableDay: 2,
+      });
+      const { service } = buildService(em);
+
+      const result = await service.getStatus(1234);
+
+      expect(result.checkedToday).toBe(false);
+      expect(result.recoverable).toBe(false);
+      expect(result.previousDay).toBeNull();
     });
   });
 });

--- a/server-toss/src/modules/attendance/attendance.service.ts
+++ b/server-toss/src/modules/attendance/attendance.service.ts
@@ -160,9 +160,9 @@ export class AttendanceService {
       throw new ForbiddenException("등록되지 않은 광고예요.");
     }
 
-    const today = getSeoulDayRange().start.getTime();
-
     const { newDay, rewardedDay } = await this.em.transactional(async (em) => {
+      // 자정 경계 race 방지를 위해 today를 트랜잭션 내부에서 계산한다.
+      const today = getSeoulDayRange().start.getTime();
       const attendance = await em.findOne(
         Attendance,
         { userKey },

--- a/server-toss/src/modules/attendance/attendance.service.ts
+++ b/server-toss/src/modules/attendance/attendance.service.ts
@@ -160,6 +160,8 @@ export class AttendanceService {
       throw new ForbiddenException("등록되지 않은 광고예요.");
     }
 
+    const today = getSeoulDayRange().start.getTime();
+
     const { newDay, rewardedDay } = await this.em.transactional(async (em) => {
       const attendance = await em.findOne(
         Attendance,
@@ -177,6 +179,19 @@ export class AttendanceService {
           "복구할 연속 출석이 없어요",
         );
         throw new ForbiddenException("복구할 연속 출석이 없어요.");
+      }
+
+      // 만회는 끊김을 감지한 당일(KST)에만 유효 — 오늘 체크인 기록이 아니면 만료.
+      if (this.dayStartMs(attendance.lastCheckedDate) !== today) {
+        this.logger.warn(
+          {
+            event: "attendance.recover.denied",
+            userKey,
+            reason: "recovery_window_expired",
+          },
+          "복구 기간이 지났어요",
+        );
+        throw new ForbiddenException("복구 기간이 지났어요.");
       }
 
       const restored = nextCycleDay(attendance.recoverableDay);
@@ -211,6 +226,30 @@ export class AttendanceService {
     return { cycleDay: newDay, rewardedDay };
   }
 
+  // 복구를 포기하고 끊긴 채로 새로 시작한다. 이미 리셋된 cycleDay는 두고
+  // 복구 대상(recoverableDay)만 비워 카드가 정상 상태로 돌아가게 한다.
+  async declineRecovery(userKey: number): Promise<AttendanceStatusResponse> {
+    await this.em.transactional(async (em) => {
+      const attendance = await em.findOne(
+        Attendance,
+        { userKey },
+        { lockMode: LockMode.PESSIMISTIC_WRITE },
+      );
+
+      if (attendance && attendance.recoverableDay != null) {
+        attendance.recoverableDay = null;
+        await em.flush();
+      }
+    });
+
+    this.logger.log(
+      { event: "attendance.recover.declined", userKey },
+      "연속 출석 복구 포기",
+    );
+
+    return this.getStatus(userKey);
+  }
+
   async getStatus(userKey: number): Promise<AttendanceStatusResponse> {
     const today = getSeoulDayRange().start.getTime();
     const attendance = await this.em.findOne(Attendance, { userKey });
@@ -226,12 +265,13 @@ export class AttendanceService {
     }
 
     const checkedToday = this.dayStartMs(attendance.lastCheckedDate) === today;
+    const recoverable = attendance.recoverableDay != null && checkedToday;
 
     return {
       cycleDay: attendance.cycleDay,
       checkedToday,
-      recoverable: attendance.recoverableDay != null,
-      previousDay: attendance.recoverableDay ?? null,
+      recoverable,
+      previousDay: recoverable ? attendance.recoverableDay : null,
       tomorrowMaxPoint: tomorrowMaxPoint(attendance.cycleDay),
     };
   }


### PR DESCRIPTION
## 개요

연속 출석이 끊긴 뒤 **"광고 보고 이어가기" 복구가 동작하지 않던 버그**를 수정했습니다. 광고를 끝까지 봐도 복구가 안 되고, 끊김 상태가 "1일 연속 출석 중"으로 오표기되며 복구 진입점이 1회성 시트에만 있던 문제를 함께 해결합니다.

- **원인①(핵심)**: 복구 흐름만 보상형 광고의 `userEarnedReward` reward data 필드(`unitType/unitAmount`)까지 강제 검증 → 토스 애즈/AdMob이 data를 비워 내려주면 완주해도 탈락. 백엔드 `recover()`는 `adGroupId`만 검증하므로 불필요한 단일 장애점이었음 → **이벤트 발생 여부(boolean) 판정으로 복원**(예전 정상 플로우 `useRewardAd`와 동일).
- **원인②**: 만회 유효기간이 사실상 무기한 → **끊김 감지 당일(KST)로 제한**(다음 날 자동 만료).

## 관련 이슈

- #423

## 변경 사항

### 체크리스트

- [x] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [x] 불필요한 콘솔/디버깅 코드를 제거했습니다. (로컬 검증용 임시 시트 트리거 버튼 제거)
- [x] 주석/변수명 등 가독성을 고려했습니다.
- [x] 영향 범위를 확인했습니다. (`useFullScreenAd` rewarded 분기 — 기회 충전 흐름은 비보상형이라 영향 없음)
- [x] API, DB 변경 시 문서화했습니다. (`POST /attendance/decline` 신설, Swagger 반영 / DB 스키마 변경 없음)
- [x] 새로운 의존성 추가 시 팀과 공유했습니다. (의존성 추가 없음)

## 테스트 및 검증 내용

- **client-toss**: `pnpm test` 203 pass, `qa:ci` 8 PASS(UX Writing·Dark Pattern·Ad Integration 포함), lint/format clean
- **server-toss**: `pnpm test` 236 pass(`NODE_ENV=test`), lint/format clean

## AI 활용 점검

- Claude로 원인 분석(예전 정상 보상형 플로우 git 추적 비교), 수정 설계, 테스트 작성, 정적검사까지 수행.

## 추가 참고 사항


## Summary by CodeRabbit

## 주요 변경사항

* **새로운 기능**
  * 끊긴 출석 복구 기능 추가
  * 출석 복구 포기 옵션 추가
  * 앱 브랜드명 변경: "우리 모두 다빈치" → "똑같이 그려봐"

* **버그 수정**
  * 광고 보상 완료 감지 로직 개선
  * 출석 복구 기간 만료 확인 추가

* **개선사항**
  * UI 텍스트 및 안내 메시지 업데이트
  * 카드 제목 변경 ("오늘의 다빈치" → "기억력 TOP3")
  * 레이아웃 및 표시 요소 개선

* **테스트**
  * 신기능에 대한 테스트 커버리지 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->