### PR TITLE
[fix] Security Audit Report CI 'Argument list too long' 해소

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,9 @@ jobs:
         run: |
           pnpm audit --audit-level=high 2>&1 | tee audit-output.txt || true
           echo "audit_result<<EOF" >> $GITHUB_OUTPUT
-          cat audit-output.txt >> $GITHUB_OUTPUT
+          # 리포트 스크립트가 어차피 앞 2000자만 사용한다. 전체 출력을 GITHUB_OUTPUT으로
+          # 흘리면 후속 스텝(github-script)의 env 크기가 ARG_MAX를 넘겨 spawn이 실패하므로 절단한다.
+          head -c 2000 audit-output.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
         continue-on-error: true
 
@@ -137,7 +139,9 @@ jobs:
         run: |
           pnpm audit --audit-level=high 2>&1 | tee audit-output.txt || true
           echo "audit_result<<EOF" >> $GITHUB_OUTPUT
-          cat audit-output.txt >> $GITHUB_OUTPUT
+          # 리포트 스크립트가 어차피 앞 2000자만 사용한다. 전체 출력을 GITHUB_OUTPUT으로
+          # 흘리면 후속 스텝(github-script)의 env 크기가 ARG_MAX를 넘겨 spawn이 실패하므로 절단한다.
+          head -c 2000 audit-output.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
         continue-on-error: true
 
@@ -390,7 +394,9 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm audit --audit-level=high 2>&1 | tee audit-output.txt || true
           echo "result<<EOF" >> $GITHUB_OUTPUT
-          cat audit-output.txt >> $GITHUB_OUTPUT
+          # 리포트 스크립트가 어차피 앞 2000자만 사용한다. 전체 출력을 GITHUB_OUTPUT으로
+          # 흘리면 후속 스텝(github-script)의 env 크기가 ARG_MAX를 넘겨 spawn이 실패하므로 절단한다.
+          head -c 2000 audit-output.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
         continue-on-error: true
 
@@ -401,12 +407,15 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm audit --audit-level=high 2>&1 | tee audit-output.txt || true
           echo "result<<EOF" >> $GITHUB_OUTPUT
-          cat audit-output.txt >> $GITHUB_OUTPUT
+          # 리포트 스크립트가 어차피 앞 2000자만 사용한다. 전체 출력을 GITHUB_OUTPUT으로
+          # 흘리면 후속 스텝(github-script)의 env 크기가 ARG_MAX를 넘겨 spawn이 실패하므로 절단한다.
+          head -c 2000 audit-output.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
         continue-on-error: true
 
       - name: Post Security Audit Report
         uses: actions/github-script@v8
+        continue-on-error: true
         env:
           CLIENT_AUDIT: ${{ steps.client-audit.outputs.result }}
           SERVER_AUDIT: ${{ steps.server-audit.outputs.result }}


### PR DESCRIPTION
## 개요

PR 생성 시 실패하던 **Security Audit Report** CI 잡(`Post Security Audit Report` 스텝의 `Argument list too long`)을 해소했어요.

## 관련 이슈

Closes #428

## 변경 사항

- `pnpm audit` 출력을 `$GITHUB_OUTPUT`에 담기 전 `head -c 2000`으로 절단. 리포트 스크립트가 이미 `.slice(0, 2000)`만 쓰므로 표시 내용 손실 없음.
- 절단으로 후속 `actions/github-script` 스텝의 env 크기가 작아져 node 프로세스 spawn의 `ARG_MAX` 초과(`E2BIG`)가 사라짐.
- (보강) `Post Security Audit Report` 스텝에 `continue-on-error: true` — 정보성 리포트가 PR 체크를 막지 않게.
- 동일 패턴을 쓰는 client/server 잡의 인라인 audit 스텝에도 같은 절단을 적용(재발 방지).

## 원인

레포 의존성 취약점이 많아(80여 건) `pnpm audit` 전체 텍스트가 수십 KB에 달했고, 이를 환경변수(`CLIENT_AUDIT`/`SERVER_AUDIT`)로 통째로 전달하면서 node 프로세스 spawn 시 환경 크기가 ARG_MAX를 초과했어요. 감사 단계 자체는 통과하며, 실패는 리포트 게시 단계의 인프라 문제였습니다.

## 테스트 및 검증 내용

- `js-yaml`로 워크플로 파싱 정상 확인.
- 이 PR이 열릴 때 `Security Audit Report` 잡(트리거: `pull_request` opened)이 green으로 끝나는지 확인 예정.

## AI 활용 점검

실패 로그 분석(`Argument list too long` → ARG_MAX/E2BIG 원인 규명)과 최소 수정안 도출에 Claude Code를 활용했어요.

## 추가 참고 사항

취약점 자체 해소(의존성 업그레이드)는 별도 작업이며, 본 PR은 리포트 잡의 인프라 버그만 수정해요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 보안 감사 결과가 너무 길어 후속 단계에서 실패하던 문제를 완화했습니다.
  * 감사 출력은 최대 2,000자까지만 전달하도록 변경해 워크플로우 안정성을 높였습니다.
  * 보안 감사 보고 단계에서 발생하는 오류가 전체 작업 실패로 이어지지 않도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->