### PR TITLE
[hotfix] 미션 중복 노출·친구초대 오카운트 수정

### DIFF
--- a/server-toss/src/migrations/Migration20260626000000.ts
+++ b/server-toss/src/migrations/Migration20260626000000.ts
@@ -1,0 +1,61 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20260626000000 extends Migration {
+  // 미션 제목 리워딩 이력으로 시드가 title 기준 매칭을 하던 동안, 같은 미션 슬롯
+  // (period+objective_type+category)에 옛 제목 행과 새 제목 행이 중복 생성됐다.
+  // 이로 인해 오늘의 미션에 같은 미션이 2번 노출되고, 랜덤 풀 오염으로 일부 미션이
+  // 누락됐다. 자연 키별로 canonical(MIN id) 하나만 남기고, 중복 행을 참조하는
+  // user_missions를 canonical로 병합·재지정한 뒤 중복 mission 행을 삭제한다.
+  // (시드 매칭이 자연 키로 바뀌어 재발하지 않으므로 1회성 정합화.)
+  override up(): void {
+    // 자연 키별 canonical(MIN id) 매핑. 임시 테이블은 트랜잭션 암묵 커밋을 일으키지 않는다.
+    this.addSql(
+      "create temporary table `_mission_dedup` as " +
+        "select m.`id` as mission_id, (" +
+        "  select min(m2.`id`) from `missions` m2 " +
+        "  where m2.`period` = m.`period` " +
+        "    and m2.`objective_type` = m.`objective_type` " +
+        "    and coalesce(m2.`category`, '') = coalesce(m.`category`, '')" +
+        ") as canonical_id " +
+        "from `missions` m;",
+    );
+
+    // 같은 user+날짜에 canonical과 중복 행이 둘 다 할당된 경우, 진행도를 canonical로 병합.
+    this.addSql(
+      "update `user_missions` c " +
+        "join `user_missions` dup on dup.`user_key` = c.`user_key` and dup.`created_at` = c.`created_at` " +
+        "join `_mission_dedup` d on d.`mission_id` = dup.`mission_id` and d.`canonical_id` = c.`mission_id` and d.`mission_id` <> d.`canonical_id` " +
+        "set c.`current_count` = greatest(c.`current_count`, dup.`current_count`), " +
+        "    c.`completed_at` = coalesce(c.`completed_at`, dup.`completed_at`);",
+    );
+
+    // 병합 후 충돌하는 중복 user_missions 삭제(canonical이 이미 있는 경우).
+    this.addSql(
+      "delete um from `user_missions` um " +
+        "join `_mission_dedup` d on d.`mission_id` = um.`mission_id` and d.`mission_id` <> d.`canonical_id` " +
+        "where exists (" +
+        "  select 1 from `user_missions` c " +
+        "  where c.`user_key` = um.`user_key` and c.`created_at` = um.`created_at` and c.`mission_id` = d.`canonical_id`" +
+        ");",
+    );
+
+    // 충돌하지 않는 나머지 중복 user_missions는 canonical로 재지정.
+    this.addSql(
+      "update `user_missions` um " +
+        "join `_mission_dedup` d on d.`mission_id` = um.`mission_id` and d.`mission_id` <> d.`canonical_id` " +
+        "set um.`mission_id` = d.`canonical_id`;",
+    );
+
+    // 참조가 없어진 중복 mission 행 삭제.
+    this.addSql(
+      "delete m from `missions` m " +
+        "join `_mission_dedup` d on d.`mission_id` = m.`id` and d.`mission_id` <> d.`canonical_id`;",
+    );
+
+    this.addSql("drop temporary table `_mission_dedup`;");
+  }
+
+  override down(): void {
+    // 데이터 정합화 마이그레이션 — 병합·삭제된 중복 행을 복원할 수 없어 되돌리지 않는다.
+  }
+}

--- a/server-toss/src/migrations/Migration20260626010000.ts
+++ b/server-toss/src/migrations/Migration20260626010000.ts
@@ -1,0 +1,31 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20260626010000 extends Migration {
+  // 친구초대(invite) 미션 진행도 재정합화.
+  // 그림 제출이 invite 미션을 잘못 증가시키던 버그(findActiveDrawingMissions가
+  // INVITE를 포함 + SimpleActionCommand 무조건 매칭)로, 공유 0회인데 invite가
+  // 부풀려졌다. 코드 수정과 함께 배포되며, 이미 부풀려진 미완료 invite 행을
+  // 당일 share_logs 실개수로 되돌린다(Migration20260625000000의 재적용 — 버그가
+  // 그 이후로도 계속 부풀렸기 때문).
+  //
+  // 주의: 거짓 '완료'(completed_at 존재)된 invite 행은 보상이 이미 지급됐을 수
+  // 있어 여기서 건드리지 않는다(되돌리면 재완료 시 이중 보상 위험). 완료·보상
+  // 회수는 별도 협의 후 처리한다.
+  override up(): void {
+    this.addSql(
+      "update `user_missions` um " +
+        "join `missions` m on m.`id` = um.`mission_id` " +
+        "set um.`current_count` = least(m.`required_count`, (" +
+        "select count(*) from `share_logs` sl " +
+        "where sl.`user_key` = um.`user_key` " +
+        "and sl.`created_at` >= um.`created_at` " +
+        "and sl.`created_at` < um.`created_at` + interval 1 day" +
+        ")) " +
+        "where m.`objective_type` = 'invite' and um.`completed_at` is null;",
+    );
+  }
+
+  override down(): void {
+    // 데이터 정합화 마이그레이션 — 부풀려졌던 원래 값을 복원할 수 없어 되돌리지 않는다.
+  }
+}

--- a/server-toss/src/modules/mission/repository/mission.repository.ts
+++ b/server-toss/src/modules/mission/repository/mission.repository.ts
@@ -2,12 +2,14 @@ import { EntityRepository } from "@mikro-orm/mysql";
 import { Mission, MissionPeriod } from "../entity/mission.entity";
 
 export class MissionRepository extends EntityRepository<Mission> {
+  // id 오름차순 고정 — 같은 슬롯 중복 행이 남아 있어도 dedupeByObjective가 항상
+  // 가장 작은 id(시드/마이그레이션 canonical)를 고르도록 결정성을 보장한다.
   async findFixed(period: MissionPeriod): Promise<Mission[]> {
-    return this.find({ period, isFixed: true });
+    return this.find({ period, isFixed: true }, { orderBy: { id: "asc" } });
   }
 
   async findRandom(period: MissionPeriod): Promise<Mission[]> {
-    return this.find({ period, isFixed: false });
+    return this.find({ period, isFixed: false }, { orderBy: { id: "asc" } });
   }
 
   async findTutorial(): Promise<Mission[]> {

--- a/server-toss/src/modules/mission/repository/user-mission.repository.ts
+++ b/server-toss/src/modules/mission/repository/user-mission.repository.ts
@@ -78,11 +78,18 @@ export class UserMissionRepository extends EntityRepository<UserMission> {
       {
         user: { userKey },
         completedAt: null,
+        // 그림 제출이 실제로 진행시키는 objectiveType만 허용(allowlist).
+        // 블록리스트로 두면 INVITE/SHARE/VISIT_* 처럼 그림과 무관한 미션이 새어
+        // 들어와 SimpleActionCommand(항상 매칭)로 잘못 증가한다. INVITE는 공유
+        // (syncInviteProgress) 전용이라 이 경로에서 반드시 제외돼야 한다.
         mission: {
           objectiveType: {
-            $nin: [
-              ObjectiveType.MISSION_COMPLETED,
-              ObjectiveType.TUTORIAL_COMPLETED,
+            $in: [
+              ObjectiveType.SUBMIT,
+              ObjectiveType.SCORE,
+              ObjectiveType.PENALTY,
+              ObjectiveType.DAILY_SUBMIT,
+              ObjectiveType.DAILY_SCORE,
             ],
           },
         },

--- a/server-toss/src/modules/mission/service/assign-mission.service.ts
+++ b/server-toss/src/modules/mission/service/assign-mission.service.ts
@@ -8,6 +8,10 @@ import { DAILY_RANDOM_COUNT, WEEKLY_RANDOM_COUNT } from "../mission.constants";
 import { MissionRepository } from "../repository/mission.repository";
 import { UserMissionRepository } from "../repository/user-mission.repository";
 
+// 미션 슬롯 식별자(시드의 자연 키와 동일 개념, period는 호출 단위로 고정).
+const objectiveKey = (mission: Mission): string =>
+  `${mission.objectiveType}|${mission.category ?? ""}`;
+
 @Injectable()
 export class AssignMissionService {
   private readonly logger = new Logger(AssignMissionService.name);
@@ -101,8 +105,15 @@ export class AssignMissionService {
     periodStart: Date,
     randomCount: number,
   ): Promise<UserMission[]> {
-    const fixedMissions = await this.missionRepository.findFixed(period);
-    const randomMissions = await this.missionRepository.findRandom(period);
+    // 같은 미션 슬롯(objectiveType+category)의 행이 데이터상 중복돼 있어도 하루에
+    // 한 번만 배정되도록 방어적으로 중복을 제거한다(고정 우선, 랜덤 풀 오염 방지).
+    const fixedMissions = this.dedupeByObjective(
+      await this.missionRepository.findFixed(period),
+    );
+    const fixedKeys = new Set(fixedMissions.map((m) => objectiveKey(m)));
+    const randomMissions = this.dedupeByObjective(
+      await this.missionRepository.findRandom(period),
+    ).filter((mission) => !fixedKeys.has(objectiveKey(mission)));
 
     const selected = [
       ...fixedMissions,
@@ -112,6 +123,16 @@ export class AssignMissionService {
     return selected.map((mission) =>
       this.userMissionRepository.createForUser(userKey, mission, periodStart),
     );
+  }
+
+  private dedupeByObjective(missions: Mission[]): Mission[] {
+    const seen = new Set<string>();
+    return missions.filter((mission) => {
+      const key = objectiveKey(mission);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
   }
 
   private isDuplicateKeyError(err: unknown): boolean {

--- a/server-toss/src/modules/mission/service/mission.processor.ts
+++ b/server-toss/src/modules/mission/service/mission.processor.ts
@@ -41,7 +41,8 @@ export class MissionProcessor {
       [ObjectiveType.VISIT_MISSION_TAB]: simpleAction,
       [ObjectiveType.VISIT_DRAWING_DETAIL]: simpleAction,
       [ObjectiveType.SHARE]: simpleAction,
-      [ObjectiveType.INVITE]: simpleAction,
+      // INVITE는 공유 적립(syncInviteProgress)에서만 진행한다. 프로세서가 어떤
+      // 경로로도 INVITE를 증가시키지 못하도록 commandMap에서 제외(이중 안전망).
     };
   }
 

--- a/server-toss/src/modules/mission/service/mission.seed.ts
+++ b/server-toss/src/modules/mission/service/mission.seed.ts
@@ -32,9 +32,25 @@ const MissionsFileSchema = z
     (missions) =>
       new Set(missions.map((q) => q.title)).size === missions.length,
     { message: "미션 제목이 중복됩니다" },
+  )
+  .refine(
+    (missions) =>
+      new Set(missions.map(missionNaturalKey)).size === missions.length,
+    {
+      message: "미션 자연 키(period+objectiveType+category)가 중복됩니다",
+    },
   );
 
 export type MissionDefinition = z.infer<typeof MissionDefinitionSchema>;
+
+// 미션의 안정 식별자. title·requiredCount·threshold는 리워딩/튜닝으로 바뀌므로
+// 식별자에서 제외하고, 슬롯을 규정하는 (period, objectiveType, category)만 쓴다.
+// 이 키로 시드를 매칭해야 제목/수치 변경 시 새 행을 만들지 않고 제자리 업데이트한다.
+const missionNaturalKey = (m: {
+  period: MissionPeriod;
+  objectiveType: ObjectiveType;
+  category?: string | null;
+}): string => `${m.period}|${m.objectiveType}|${m.category ?? ""}`;
 
 // missions.json의 rewardAmount는 "0=보상 없음 / 양수=표준 보상"의 on/off 플래그로만 쓰고,
 // 실제 지급액은 단일 소스 REWARD_POINT로 정규화한다(포인트 보상에 한함).
@@ -78,10 +94,10 @@ export class MissionSeedService {
       const userMissionRepo = txEm.getRepository(UserMission);
 
       const allMissions = await missionRepo.findAll();
-      const jsonTitles = new Set(data.map((d) => d.title));
+      const jsonKeys = new Set(data.map(missionNaturalKey));
 
       for (const mission of allMissions) {
-        if (jsonTitles.has(mission.title)) continue;
+        if (jsonKeys.has(missionNaturalKey(mission))) continue;
 
         const userMissionCount = await userMissionRepo.count({ mission });
 
@@ -111,14 +127,17 @@ export class MissionSeedService {
 
       await txEm.flush();
 
-      const existingByTitle = new Map(
-        allMissions
-          .filter((q) => jsonTitles.has(q.title))
-          .map((q) => [q.title, q]),
-      );
+      // 자연 키 → 기존 미션. 중복 행이 남아 있으면 가장 오래된(먼저 조회된) 행을
+      // canonical로 삼는다(복구 마이그레이션의 MIN(id) 선택과 일치).
+      const existingByKey = new Map<string, Mission>();
+      for (const mission of allMissions) {
+        const key = missionNaturalKey(mission);
+        if (!jsonKeys.has(key)) continue;
+        if (!existingByKey.has(key)) existingByKey.set(key, mission);
+      }
 
       for (const def of data) {
-        const existing = existingByTitle.get(def.title);
+        const existing = existingByKey.get(missionNaturalKey(def));
 
         if (existing) {
           if (this.applyChanges(existing, def)) {
@@ -161,6 +180,11 @@ export class MissionSeedService {
 
   private applyChanges(mission: Mission, def: MissionDefinition): boolean {
     let changed = false;
+    // title은 더 이상 매칭 키가 아니므로(자연 키로 매칭) 제자리에서 동기화한다.
+    if (mission.title !== def.title) {
+      mission.title = def.title;
+      changed = true;
+    }
     if (mission.period !== def.period) {
       mission.period = def.period;
       changed = true;

--- a/server-toss/src/modules/mission/service/mission.seed.ts
+++ b/server-toss/src/modules/mission/service/mission.seed.ts
@@ -127,10 +127,14 @@ export class MissionSeedService {
 
       await txEm.flush();
 
-      // 자연 키 → 기존 미션. 중복 행이 남아 있으면 가장 오래된(먼저 조회된) 행을
-      // canonical로 삼는다(복구 마이그레이션의 MIN(id) 선택과 일치).
+      // 자연 키 → 기존 미션. 중복 행이 남아 있으면 가장 작은 id 행을 canonical로
+      // 삼는다(복구 마이그레이션의 MIN(id) 선택과 일치). findAll() 순서에 의존하지
+      // 않도록 id 오름차순으로 정렬한 뒤 첫 행을 고른다.
+      const orderedById = [...allMissions].sort((a, b) =>
+        a.id < b.id ? -1 : a.id > b.id ? 1 : 0,
+      );
       const existingByKey = new Map<string, Mission>();
-      for (const mission of allMissions) {
+      for (const mission of orderedById) {
         const key = missionNaturalKey(mission);
         if (!jsonKeys.has(key)) continue;
         if (!existingByKey.has(key)) existingByKey.set(key, mission);

--- a/server-toss/src/modules/mission/test/assign-mission.service.spec.ts
+++ b/server-toss/src/modules/mission/test/assign-mission.service.spec.ts
@@ -159,6 +159,74 @@ describe("미션 배정 서비스", () => {
     });
   });
 
+  describe("같은 슬롯의 미션 행이 데이터상 중복되면", () => {
+    it("objectiveType 기준으로 하루 한 번만 배정하고 랜덤 풀 오염을 막는다", async () => {
+      // 일일만 배정되도록 주간은 이미 존재 처리.
+      userMissionRepository.findCurrentMissions.mockResolvedValue([
+        buildUserMission({
+          mission: buildMission({ period: MissionPeriod.WEEKLY }),
+          createdAt: WEEK_START,
+        }),
+      ]);
+      missionRepository.findFixed.mockImplementation(async (period) =>
+        period === MissionPeriod.DAILY
+          ? [
+              buildMission({
+                id: BigInt(1),
+                title: "옛 감점",
+                objectiveType: ObjectiveType.PENALTY,
+              }),
+              buildMission({
+                id: BigInt(2),
+                title: "새 감점",
+                objectiveType: ObjectiveType.PENALTY,
+              }),
+              buildMission({
+                id: BigInt(3),
+                title: "초대",
+                objectiveType: ObjectiveType.INVITE,
+              }),
+            ]
+          : [],
+      );
+      missionRepository.findRandom.mockImplementation(async (period) =>
+        period === MissionPeriod.DAILY
+          ? [
+              buildMission({
+                id: BigInt(4),
+                title: "옛 70점",
+                objectiveType: ObjectiveType.SCORE,
+              }),
+              buildMission({
+                id: BigInt(5),
+                title: "새 70점",
+                objectiveType: ObjectiveType.SCORE,
+              }),
+              buildMission({
+                id: BigInt(6),
+                title: "2회 그림",
+                objectiveType: ObjectiveType.SUBMIT,
+              }),
+            ]
+          : [],
+      );
+
+      await service.ensureMissionsAssigned(1, window);
+
+      const objectives = userMissionRepository.createForUser.mock.calls.map(
+        (call) => (call[1] as Mission).objectiveType,
+      );
+      // 중복 PENALTY/SCORE는 각각 1회만, 랜덤 풀이 {SCORE, SUBMIT}로 줄어 2회(SUBMIT)가 항상 포함.
+      expect(
+        objectives.filter((o) => o === ObjectiveType.PENALTY),
+      ).toHaveLength(1);
+      expect(objectives.filter((o) => o === ObjectiveType.SCORE)).toHaveLength(
+        1,
+      );
+      expect(objectives).toContain(ObjectiveType.SUBMIT);
+    });
+  });
+
   describe("동시 요청으로 중복 키 에러가 발생하면", () => {
     it("ER_DUP_ENTRY는 무시한다", async () => {
       const dupError = Object.assign(new Error("Duplicate entry"), {

--- a/server-toss/src/modules/mission/test/mission.seed.spec.ts
+++ b/server-toss/src/modules/mission/test/mission.seed.spec.ts
@@ -108,12 +108,17 @@ describe("미션 시드 서비스", () => {
       expect(persisted).toHaveLength(2);
     });
 
-    it("user_mission 없는 기존 미션은 삭제한다", async () => {
-      const orphan = buildMission({ id: BigInt(99), title: "삭제될 미션" });
+    it("자연 키가 JSON에 없는 user_mission 없는 미션은 삭제한다", async () => {
+      // 자연 키(objectiveType) 자체가 JSON에 없어야 진짜 제거 대상이다.
+      const orphan = buildMission({
+        id: BigInt(99),
+        title: "삭제될 미션",
+        objectiveType: ObjectiveType.SCORE,
+      });
       const { service, removed } = setup([orphan]);
 
       const result = await service.syncMissions([
-        buildDef({ title: "새 미션" }),
+        buildDef({ title: "새 미션", objectiveType: ObjectiveType.SUBMIT }),
       ]);
 
       expect(result.deleted).toBe(1);
@@ -121,21 +126,71 @@ describe("미션 시드 서비스", () => {
       expect(result.added).toBe(1);
     });
 
-    it("user_mission 있는 기존 미션은 보존한다", async () => {
+    it("자연 키가 JSON에 없고 user_mission 있는 미션은 보존한다", async () => {
       const protectedMission = buildMission({
         id: BigInt(10),
         title: "보존될 미션",
+        objectiveType: ObjectiveType.SCORE,
       });
       const counts = new Map([[BigInt(10), 3]]);
       const { service, removed } = setup([protectedMission], counts);
 
       const result = await service.syncMissions([
-        buildDef({ title: "새 미션" }),
+        buildDef({ title: "새 미션", objectiveType: ObjectiveType.SUBMIT }),
       ]);
 
       expect(result.protected).toBe(1);
       expect(result.deleted).toBe(0);
       expect(removed).not.toContain(protectedMission);
+    });
+
+    it("제목만 바뀌면 새 행을 만들지 않고 기존 행 제목을 업데이트한다", async () => {
+      const existing = buildMission({
+        id: BigInt(1),
+        title: "오늘 감점 없는 그림 1회 달성",
+        objectiveType: ObjectiveType.PENALTY,
+      });
+      const { service, persisted, removed } = setup([existing]);
+
+      const result = await service.syncMissions([
+        buildDef({
+          title: "감점 없는 그림 1회 등록",
+          objectiveType: ObjectiveType.PENALTY,
+        }),
+      ]);
+
+      expect(result.added).toBe(0);
+      expect(result.deleted).toBe(0);
+      expect(result.updated).toBe(1);
+      expect(persisted).toHaveLength(0);
+      expect(removed).toHaveLength(0);
+      expect(existing.title).toBe("감점 없는 그림 1회 등록");
+    });
+
+    it("requiredCount가 바뀌어도 같은 슬롯으로 제자리 업데이트한다", async () => {
+      const existing = buildMission({
+        id: BigInt(1),
+        title: "이번 주 3일 동안 그림 등록",
+        period: MissionPeriod.WEEKLY,
+        objectiveType: ObjectiveType.DAILY_SUBMIT,
+        requiredCount: 3,
+      });
+      const { service, persisted } = setup([existing]);
+
+      const result = await service.syncMissions([
+        buildDef({
+          title: "이번 주 4일 동안 그림 등록",
+          period: MissionPeriod.WEEKLY,
+          objectiveType: ObjectiveType.DAILY_SUBMIT,
+          requiredCount: 4,
+        }),
+      ]);
+
+      expect(result.added).toBe(0);
+      expect(result.updated).toBe(1);
+      expect(persisted).toHaveLength(0);
+      expect(existing.requiredCount).toBe(4);
+      expect(existing.title).toBe("이번 주 4일 동안 그림 등록");
     });
 
     it("JSON에 있는 기존 미션의 필드를 업데이트한다", async () => {

--- a/server-toss/src/modules/mission/test/mission.service.spec.ts
+++ b/server-toss/src/modules/mission/test/mission.service.spec.ts
@@ -389,7 +389,7 @@ describe("MissionService", () => {
       expect(uq.currentCount).toBe(2);
     });
 
-    it("INVITE 미션이 활성 목록에 섞여 들어와도 그림 제출로는 진행되지 않아요", async () => {
+    it("친구초대 미션이 활성 목록에 섞여 들어와도 그림 제출로는 진행되지 않아요", async () => {
       // INVITE는 공유(syncInviteProgress) 전용 — 프로세서 commandMap에서 제외돼
       // 그림 제출 경로로는 절대 증가하지 않아야 한다(공유 0회인데 1로 오르던 버그 방지).
       const invite = buildUserMission({

--- a/server-toss/src/modules/mission/test/mission.service.spec.ts
+++ b/server-toss/src/modules/mission/test/mission.service.spec.ts
@@ -388,6 +388,27 @@ describe("MissionService", () => {
 
       expect(uq.currentCount).toBe(2);
     });
+
+    it("INVITE 미션이 활성 목록에 섞여 들어와도 그림 제출로는 진행되지 않아요", async () => {
+      // INVITE는 공유(syncInviteProgress) 전용 — 프로세서 commandMap에서 제외돼
+      // 그림 제출 경로로는 절대 증가하지 않아야 한다(공유 0회인데 1로 오르던 버그 방지).
+      const invite = buildUserMission({
+        mission: buildMission({
+          objectiveType: ObjectiveType.INVITE,
+          requiredCount: 5,
+          progressPeriod: ProgressPeriod.NONE,
+        }),
+        currentCount: 0,
+      });
+      userMissionRepository.findActiveDrawingMissions.mockResolvedValue([
+        invite,
+      ]);
+
+      await service.onDrawingSubmitted(1234, drawingContext);
+
+      expect(invite.currentCount).toBe(0);
+      expect(invite.completedAt).toBeNull();
+    });
   });
 
   describe("친구초대 미션 동기화는 ShareLog 실개수를 단일 소스로 멱등하게 반영해요", () => {


### PR DESCRIPTION
## 개요

프로모션에서 오늘의 미션이 잘못 보이던 두 버그를 수정했어요.

1. **미션 중복 노출·일부 누락** — 시드가 미션을 `title`로 매칭해, 제목 리워딩 때 옛 제목 행은 남고 새 제목 행이 따로 생겨 같은 미션이 둘씩 존재한 게 원인이에요(랜덤 풀이 오염돼 "오늘 그림 2회" 같은 미션이 밀려 빠지기도 했어요).
2. **친구 초대를 안 했는데 친구초대 미션이 오름** — 그림 제출 진행 경로(`findActiveDrawingMissions`)가 INVITE까지 포함하고, INVITE 커맨드가 무조건 매칭이라 **그림을 낼 때마다 invite가 +1** 되던 게 원인이에요.

## 관련 이슈

-

## 변경 사항

### ① 미션 중복

- 시드 매칭을 `title` → 자연 키 `(period, objectiveType, category)`로 변경 — 제목·요구치가 바뀌어도 새 행을 만들지 않고 제자리 업데이트해요.
- 미션 할당 시 같은 슬롯(objectiveType)을 하루 한 번만 배정하도록 중복 제거(방어).
- 기존 중복 행 정합화 마이그레이션 — canonical(가장 오래된 행)으로 `user_missions`를 병합·재지정하고 중복 미션 행을 삭제해요.

### ② 친구초대 오카운트

- `findActiveDrawingMissions`를 허용리스트(`SUBMIT/SCORE/PENALTY/DAILY_SUBMIT/DAILY_SCORE`)로 좁히고, 프로세서 `commandMap`에서 `INVITE`를 제거했어요 → 그림 제출이 invite를 올리지 않아요. invite는 공유(`syncInviteProgress`)로만 진행돼요.
- 부풀려진 **미완료** invite 진행도를 당일 `share_logs` 실개수로 되돌리는 마이그레이션을 추가했어요.
- 거짓 완료·이미 지급된 보상은 그대로 둬요(소액 + 일일 리셋, 코드 수정으로 재발 차단).
- 그림 제출 미션(2회 등록·감점 없음·70점 등)은 전과 동일하게 적립돼요.

### 체크리스트

- [x] 코드 스타일/린트 규칙을 준수했어요.
- [x] 주석·변수명 가독성을 고려했어요.
- [x] 영향 범위를 확인했어요.
- [x] DB 변경(데이터 정합화 마이그레이션 2건)을 문서화했어요.

## 테스트 및 검증 내용

- 미션 테스트 45개 통과, server-toss lint 0 errors / build 통과.
- 추가: "그림 제출로는 invite가 증가하지 않는다", 시드 "제목만 바뀌면 제자리 업데이트" 케이스.
- 무관한 기존 실패 1건(`drawing-access.service.spec`)은 develop에도 존재해요.

## AI 활용 점검

원인 전수조사(시드 매칭·미션 진행 경로 추적), 수정·테스트·마이그레이션 작성에 Claude Code를 활용했어요.

## 추가 참고 사항

- 데이터 마이그레이션 2건은 배포 파이프라인 CLI로 실행돼요(프로덕션은 부팅 시 자동 마이그레이션을 하지 않아요).
- invite는 일일 미션이라, 코드 수정 배포 후 다음 날부터는 자동으로 정상화돼요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 중복 미션과 사용자 진행 데이터가 정리되어, 동일한 미션이 여러 번 보이거나 잘못 집계되는 문제가 개선되었습니다.
  * 일일 보상/도전 진행 수치가 실제 활동 수에 맞게 다시 계산되도록 수정했습니다.
  * 그림 제출 흐름에서 관련 없는 미션이 섞이거나, 초대 관련 미션이 잘못 진행되는 문제가 방지되었습니다.
  * 미션 자동 배정 시 같은 유형의 미션이 중복으로 배정되지 않도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->