### PR TITLE
[fix] 미션 마이그레이션 배포 실패(MySQL 1093) 수정 및 검증 게이트 추가

### DIFF
--- a/.claude/hooks/verify-migrations.sh
+++ b/.claude/hooks/verify-migrations.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# PreToolUse(Bash) 게이트 — git commit/push에 server-toss 마이그레이션 변경이 포함되면
+# 실제 MySQL(daVinci_toss_migcheck)에 전체 마이그레이션을 처음부터 적용해 본다.
+# 실패(예: MySQL 1093 같은 방언 오류)하면 exit 2로 커밋/푸시를 차단한다.
+# jest는 MikroORM을 모킹해 raw SQL 오류를 못 잡으므로, 이 훅이 유일한 실DB 검증이다.
+# 긴급 우회: SKIP_MIGRATION_CHECK=1
+
+INPUT=$(cat)
+CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')
+
+# git commit / git push 가 아니면 무관 — 통과
+case "$CMD" in
+  *"git commit"* | *"git push"*) ;;
+  *) exit 0 ;;
+esac
+
+[ "${SKIP_MIGRATION_CHECK:-}" = "1" ] && exit 0
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+# 변경된 마이그레이션 탐지 — staged(commit) + 미푸시 커밋(push)
+CHANGED=$(
+  {
+    git diff --cached --name-only
+    git diff --name-only @{u}..HEAD 2>/dev/null
+  } | grep -E '^server-toss/src/migrations/.*\.ts$' | sort -u
+)
+[ -z "$CHANGED" ] && exit 0 # 마이그레이션 무관 커밋/푸시 — 즉시 통과(오버헤드 0)
+
+echo "마이그레이션 변경 감지 → 실 MySQL 검증을 시작합니다." >&2
+
+# MySQL 기동 + healthy 대기
+if ! pnpm infra:mysql:up >/dev/null 2>&1; then
+  echo "MySQL 기동 실패 — 마이그레이션을 검증할 수 없어 차단합니다. (도커 확인 후 재시도, 긴급 시 SKIP_MIGRATION_CHECK=1)" >&2
+  exit 2
+fi
+for _ in $(seq 1 30); do
+  docker exec daVinci-mysql mysqladmin ping -h127.0.0.1 --silent 2>/dev/null && break
+  sleep 2
+done
+
+# config가 dist/ 엔티티를 require하므로 빌드 필요
+if ! pnpm --filter server-toss build >/dev/null 2>&1; then
+  echo "server-toss 빌드 실패 — 마이그레이션 검증 불가, 차단합니다." >&2
+  exit 2
+fi
+
+# 일회용 검증 DB를 매번 비우고(드롭→생성) 전체 마이그레이션을 처음부터 적용한다.
+# dev DB(daVinci_toss)는 건드리지 않는다. migration:fresh는 엔티티 메타데이터에 없는
+# 테이블(예: daily_user_rankings)을 못 지워 재실행이 깨지므로, 빈 DB + migration:up을 쓴다.
+docker exec daVinci-mysql mysql -uroot \
+  -e "drop database if exists daVinci_toss_migcheck; create database daVinci_toss_migcheck;" 2>/dev/null
+
+LOG=$(mktemp)
+MYSQL_DATABASE=daVinci_toss_migcheck MYSQL_HOST=127.0.0.1 MYSQL_PORT=3306 \
+  MYSQL_USER=root MYSQL_PASSWORD= NODE_ENV=test \
+  pnpm --filter server-toss exec mikro-orm migration:up \
+  --config mikro-orm.migration.config.cjs >"$LOG" 2>&1
+RESULT=$?
+
+# 검증 DB 이름으로 생성되는 스냅샷 아티팩트는 커밋 대상이 아니므로 정리.
+rm -f "$CLAUDE_PROJECT_DIR"/server-toss/src/migrations/.snapshot-daVinci_toss_migcheck.json 2>/dev/null
+
+if [ "$RESULT" -eq 0 ]; then
+  rm -f "$LOG"
+  echo "마이그레이션 실 MySQL 검증 통과." >&2
+  exit 0
+else
+  echo "── 마이그레이션 검증 실패 (커밋/푸시 차단) ──" >&2
+  tail -30 "$LOG" >&2
+  rm -f "$LOG"
+  echo "── SQL/마이그레이션을 수정해 다시 시도하세요. 긴급 우회: SKIP_MIGRATION_CHECK=1 ──" >&2
+  exit 2
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,12 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-dangerous.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/verify-migrations.sh",
+            "timeout": 600,
+            "statusMessage": "마이그레이션 실 MySQL 검증 중..."
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ we-are-all-da-vinci.ait
 AGENTS.md
 
 **/tokens.json
+# AI 하네스 마이그레이션 검증(.claude/hooks/verify-migrations.sh)의 일회용 DB 스냅샷
+server-toss/src/migrations/.snapshot-daVinci_toss_migcheck.json

--- a/server-toss/CLAUDE.md
+++ b/server-toss/CLAUDE.md
@@ -13,6 +13,7 @@ Apps-in-Toss 미니앱(`client-toss`)용 NestJS 11.x **REST 전용** 백엔드. 
 - **로그는 `(logObject, "한국어 메시지")` 2인자 필수.** 객체만 넘기거나 문자열 한 줄 로그 금지. `logObject`의 첫 키는 항상 `event: "<domain>.<action>.<outcome>"` → "로깅" 절 참조.
 - **MikroORM v7에 `persistAndFlush` 없음** → `em.persist(e); await em.flush()`.
 - **새 MikroORM 엔티티는 두 곳 모두 등록할 것.** `src/mikro-orm.config.ts`(런타임 — `app.module`이 `forRoot`, 부팅 시 `migrator.up`)와 `mikro-orm.migration.config.cjs`(배포 마이그레이션 CLI — `deploy-toss/Dockerfile`이 `--config …cjs`, `./dist/...`에서 require → `build` 후 반영). 한쪽만 등록하면 로컬에서만 동작하고 **배포 마이그레이션에서 누락**된다.
+- **마이그레이션은 jest로 검증되지 않는다.** raw SQL이라 jest의 MikroORM 모킹으로는 방언 오류(예: MySQL 1093)가 안 잡히고, 배포 파이프라인 `migration:up`에서 처음 실행돼 배포를 깨뜨린다. 새/수정 마이그레이션은 **반드시 실제 MySQL에 적용**해 검증한다: `pnpm infra:mysql:up` → `pnpm --filter server-toss build` → 일회용 DB(`daVinci_toss_migcheck`)에 `migration:fresh`. 커밋/푸시 시 `.claude/hooks/verify-migrations.sh`(PreToolUse 게이트)가 이를 자동 강제하고 실패하면 차단한다(긴급 우회 `SKIP_MIGRATION_CHECK=1`).
 - **테스트 `describe`·`it` 설명은 모두 한국어.** 컴포넌트·클래스·훅 이름이나 HTTP 경로를 그대로 suite 제목으로 쓰지 말 것. ✗ `describe("PointController (e2e)")`, `describe("POST /attendance/check-in")` → ✓ `describe("포인트 API")`, `describe("출석 체크인")`. (새/수정 spec에서 영문 suite 제목은 반드시 한국어 설명으로 바꾼다.)
 
 ## 명령어

--- a/server-toss/src/migrations/Migration20260626000000.ts
+++ b/server-toss/src/migrations/Migration20260626000000.ts
@@ -30,13 +30,15 @@ export class Migration20260626000000 extends Migration {
     );
 
     // 병합 후 충돌하는 중복 user_missions 삭제(canonical이 이미 있는 경우).
+    // MySQL은 삭제 대상 테이블을 서브쿼리에서 참조하면 1093(ER_UPDATE_TABLE_USED)으로
+    // 막으므로, EXISTS 서브쿼리 대신 canonical 행(c)과의 JOIN으로 표현한다.
     this.addSql(
       "delete um from `user_missions` um " +
         "join `_mission_dedup` d on d.`mission_id` = um.`mission_id` and d.`mission_id` <> d.`canonical_id` " +
-        "where exists (" +
-        "  select 1 from `user_missions` c " +
-        "  where c.`user_key` = um.`user_key` and c.`created_at` = um.`created_at` and c.`mission_id` = d.`canonical_id`" +
-        ");",
+        "join `user_missions` c " +
+        "  on c.`user_key` = um.`user_key` " +
+        " and c.`created_at` = um.`created_at` " +
+        " and c.`mission_id` = d.`canonical_id`;",
     );
 
     // 충돌하지 않는 나머지 중복 user_missions는 canonical로 재지정.


### PR DESCRIPTION
## 개요

PR #435 배포가 마이그레이션 단계에서 실패해 프로덕션에 반영되지 못한 문제를 핫픽스해요. 더불어, 같은 사고가 또 나지 않도록 **마이그레이션을 실제 MySQL로 검증하는 커밋 게이트(AI 하네스 훅)** 를 추가했어요.

## 관련 이슈

-

## 변경 사항

### ① 마이그레이션 1093 수정 (배포 실패 원인)

- `Migration20260626000000`의 충돌 `user_missions` 삭제문이 **삭제 대상 테이블을 `WHERE EXISTS` 서브쿼리에서 참조**해 MySQL `ER_UPDATE_TABLE_USED(1093)` 로 실패했어요(배포 파이프라인 `migration:up`에서 중단 → 프로덕션 구버전 유지).
- `EXISTS` 서브쿼리를 canonical 행과의 **JOIN**으로 바꿔 같은 의미로 우회했어요.
- 실제 MySQL에서 전체 마이그레이션이 끝까지 적용됨을 확인했어요.

### ② 재발 방지 — 마이그레이션 실 MySQL 검증 커밋 게이트

- `jest`는 MikroORM을 모킹해 raw SQL(마이그레이션)의 방언 오류를 못 잡아요. 그래서 배포 때 처음 실행되다 터졌어요.
- `.claude/hooks/verify-migrations.sh`(PreToolUse 게이트)가 **git commit/push에 마이그레이션 변경이 포함되면** 일회용 DB에 전체 마이그레이션을 적용해 보고 **실패 시 차단**해요. 마이그레이션 무관 커밋은 즉시 통과해요.
- `server-toss/CLAUDE.md`에 "마이그레이션은 실 MySQL로만 검증된다" 규칙을 명시했어요.

### 체크리스트

- [x] 코드 스타일/린트 규칙을 준수했어요.
- [x] 영향 범위를 확인했어요.
- [x] DB 변경(마이그레이션 SQL)을 실제 MySQL로 검증했어요.

## 테스트 및 검증 내용

- 실제 MySQL(`migration:up`)에 전체 마이그레이션이 1093 없이 끝까지 적용됨을 확인.
- 게이트 훅: 정상 마이그레이션 → 통과, 일부러 1093을 넣은 마이그레이션 → 차단(exit 2) 동작 확인.
- 미션 jest 45개 / lint / build 그린.

## AI 활용 점검

원인(1093) 규명·수정과 재발 방지 하네스(검증 훅) 설계·검증에 Claude Code를 활용했어요.

## 추가 참고 사항

- base는 **main**(배포 대상). 재배포 시 `migration:up`이 성공해 코드까지 반영돼요.
- `develop`에는 이번 미션 핫픽스 묶음이 아직 없어요(main 직머지) → 추후 main→develop 백머지 정합화가 필요해요.
