### PR TITLE
[fix] MySQL 테이블의 strokes 타입을 MEDIUM TEXT로 수정

### DIFF
--- a/server-toss/src/common/util/safe-parse.util.spec.ts
+++ b/server-toss/src/common/util/safe-parse.util.spec.ts
@@ -1,0 +1,44 @@
+import { safeParseStrokes } from "./safe-parse.util";
+
+describe("safeParseStrokes", () => {
+  it("정상 JSON은 그대로 파싱한다", () => {
+    const raw = JSON.stringify([
+      {
+        points: [
+          [1, 2],
+          [3, 4],
+        ],
+        color: [0, 0, 0],
+      },
+    ]);
+    expect(safeParseStrokes(raw)).toHaveLength(1);
+  });
+
+  it("잘린 JSON에서 완전한 stroke만 복구한다", () => {
+    const full = JSON.stringify([
+      {
+        points: [
+          [1, 2],
+          [3, 4],
+        ],
+        color: [0, 0, 0],
+      },
+      {
+        points: [
+          [5, 6],
+          [7, 8],
+        ],
+        color: [34, 197, 94],
+      },
+    ]);
+    const truncated = full.slice(0, full.length - 15); // 두 번째 객체 중간에서 자름
+    const result = safeParseStrokes(truncated);
+    expect(result).toHaveLength(1);
+    expect(result[0].color).toEqual([0, 0, 0]);
+  });
+
+  it("완전한 stroke가 하나도 없으면 빈 배열을 반환한다", () => {
+    const truncated = '[{"points":[[1,2';
+    expect(safeParseStrokes(truncated)).toEqual([]);
+  });
+});

--- a/server-toss/src/common/util/safe-parse.util.ts
+++ b/server-toss/src/common/util/safe-parse.util.ts
@@ -1,0 +1,71 @@
+import { Stroke } from "@toss/shared";
+
+/**
+ * strokes 문자열을 안전하게 파싱합니다.
+ * 과거 TEXT 컬럼(65535 byte) 한도로 인해 잘린 레거시 데이터가 있을 수 있어,
+ * 파싱 실패 시 완전하게 닫힌 stroke 객체까지만 최대한 복구합니다.
+ */
+export function safeParseStrokes(raw: string | null | undefined): Stroke[] {
+  if (!raw) return [];
+
+  try {
+    return JSON.parse(raw) as Stroke[];
+  } catch {
+    // strokes 데이터가 잘려서 저장되어 있어요. 일부만 복구
+    return recoverTruncatedStrokes(raw);
+  }
+}
+
+/**
+ * 최상위 배열 안의 stroke 객체는 { ... } 안에 중첩 객체가 없으므로,
+ * 중괄호 depth가 0으로 돌아오는 지점 = 하나의 stroke 객체가 완전히 닫힌 지점.
+ * 문자열 내부의 {, } 는 무시하도록 따옴표 상태도 함께 추적한다.
+ */
+function recoverTruncatedStrokes(raw: string): Stroke[] {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  let lastCompleteEnd = -1;
+
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+
+    if (ch === "{") {
+      depth++;
+    } else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        lastCompleteEnd = i; // 최상위 stroke 객체 하나가 완전히 닫힌 지점
+      }
+    }
+  }
+
+  if (lastCompleteEnd === -1) {
+    // 복구 가능한 stroke가 하나도 없어서 빈 배열을 반환
+    return [];
+  }
+
+  const truncated = raw.slice(0, lastCompleteEnd + 1) + "]";
+
+  try {
+    const recovered = JSON.parse(truncated) as Stroke[];
+    return recovered;
+  } catch {
+    // strokes 복구에 실패해서 빈 배열을 반환
+    return [];
+  }
+}

--- a/server-toss/src/migrations/.snapshot-daVinci_toss.json
+++ b/server-toss/src/migrations/.snapshot-daVinci_toss.json
@@ -487,19 +487,19 @@
         },
         "strokes": {
           "name": "strokes",
-          "type": "text",
+          "type": "mediumtext",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
           "unique": false,
-          "length": 65535,
+          "length": 16777215,
           "precision": null,
           "scale": null,
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "text"
+          "mappedType": "unknown"
         },
         "similarity": {
           "name": "similarity",
@@ -1631,19 +1631,19 @@
         },
         "strokes": {
           "name": "strokes",
-          "type": "text",
+          "type": "mediumtext",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
           "unique": false,
-          "length": 65535,
+          "length": 16777215,
           "precision": null,
           "scale": null,
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "text"
+          "mappedType": "unknown"
         }
       },
       "indexes": [
@@ -1731,19 +1731,19 @@
         },
         "strokes": {
           "name": "strokes",
-          "type": "text",
+          "type": "mediumtext",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
           "unique": false,
-          "length": 65535,
+          "length": 16777215,
           "precision": null,
           "scale": null,
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "text"
+          "mappedType": "unknown"
         },
         "drawing_id": {
           "name": "drawing_id",

--- a/server-toss/src/migrations/.snapshot-daVinci_toss.json
+++ b/server-toss/src/migrations/.snapshot-daVinci_toss.json
@@ -17,8 +17,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "created_at": {
           "name": "created_at",
@@ -33,8 +32,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "updated_at": {
           "name": "updated_at",
@@ -49,8 +47,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "ad_type": {
           "name": "ad_type",
@@ -68,8 +65,7 @@
           "enumItems": [
             "drawing",
             "attendance_recovery"
-          ],
-          "mappedType": "enum"
+          ]
         },
         "user_key": {
           "name": "user_key",
@@ -84,8 +80,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         }
       },
       "indexes": [
@@ -143,8 +138,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "prompt_id": {
           "name": "prompt_id",
@@ -159,8 +153,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "prompt_date": {
           "name": "prompt_date",
@@ -175,8 +168,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "date"
+          "enumItems": []
         }
       },
       "indexes": [
@@ -243,8 +235,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "created_at": {
           "name": "created_at",
@@ -259,8 +250,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "updated_at": {
           "name": "updated_at",
@@ -275,8 +265,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "ranking_date": {
           "name": "ranking_date",
@@ -291,8 +280,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "date"
+          "enumItems": []
         },
         "user_key": {
           "name": "user_key",
@@ -307,8 +295,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "nickname": {
           "name": "nickname",
@@ -323,8 +310,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
+          "enumItems": []
         },
         "drawing_id": {
           "name": "drawing_id",
@@ -339,8 +325,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "score": {
           "name": "score",
@@ -355,8 +340,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "double"
+          "enumItems": []
         },
         "rank": {
           "name": "rank",
@@ -371,8 +355,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "participant_count": {
           "name": "participant_count",
@@ -387,8 +370,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "submitted_at": {
           "name": "submitted_at",
@@ -403,8 +385,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         }
       },
       "indexes": [
@@ -450,8 +431,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "created_at": {
           "name": "created_at",
@@ -466,8 +446,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "updated_at": {
           "name": "updated_at",
@@ -482,8 +461,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "strokes": {
           "name": "strokes",
@@ -498,8 +476,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "unknown"
+          "enumItems": []
         },
         "similarity": {
           "name": "similarity",
@@ -514,8 +491,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "text"
+          "enumItems": []
         },
         "prompt_id": {
           "name": "prompt_id",
@@ -530,8 +506,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "score": {
           "name": "score",
@@ -546,8 +521,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "double"
+          "enumItems": []
         },
         "user_key": {
           "name": "user_key",
@@ -562,8 +536,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         }
       },
       "indexes": [
@@ -643,8 +616,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "created_at": {
           "name": "created_at",
@@ -659,8 +631,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "updated_at": {
           "name": "updated_at",
@@ -675,8 +646,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "title": {
           "name": "title",
@@ -691,8 +661,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
+          "enumItems": []
         },
         "period": {
           "name": "period",
@@ -711,8 +680,7 @@
             "daily",
             "weekly",
             "tutorial"
-          ],
-          "mappedType": "enum"
+          ]
         },
         "is_fixed": {
           "name": "is_fixed",
@@ -727,8 +695,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "boolean"
+          "enumItems": []
         },
         "objective_type": {
           "name": "objective_type",
@@ -758,8 +725,7 @@
             "invite",
             "retry",
             "tutorial_completed"
-          ],
-          "mappedType": "enum"
+          ]
         },
         "required_count": {
           "name": "required_count",
@@ -774,8 +740,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "threshold": {
           "name": "threshold",
@@ -790,8 +755,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "reward_type": {
           "name": "reward_type",
@@ -809,8 +773,7 @@
           "enumItems": [
             "point",
             "chance"
-          ],
-          "mappedType": "enum"
+          ]
         },
         "reward_amount": {
           "name": "reward_amount",
@@ -825,8 +788,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "category": {
           "name": "category",
@@ -841,8 +803,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
+          "enumItems": []
         },
         "progress_period": {
           "name": "progress_period",
@@ -862,8 +823,7 @@
             "day",
             "week",
             "month"
-          ],
-          "mappedType": "enum"
+          ]
         }
       },
       "indexes": [
@@ -898,8 +858,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "created_at": {
           "name": "created_at",
@@ -914,8 +873,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "updated_at": {
           "name": "updated_at",
@@ -930,8 +888,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "user_key": {
           "name": "user_key",
@@ -946,8 +903,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "type": {
           "name": "type",
@@ -962,8 +918,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
+          "enumItems": []
         },
         "template_code": {
           "name": "template_code",
@@ -978,8 +933,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
+          "enumItems": []
         },
         "status": {
           "name": "status",
@@ -994,8 +948,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
+          "enumItems": []
         },
         "agreed_at": {
           "name": "agreed_at",
@@ -1010,8 +963,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "rejected_at": {
           "name": "rejected_at",
@@ -1026,8 +978,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "last_event_at": {
           "name": "last_event_at",
@@ -1042,8 +993,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         }
       },
       "indexes": [
@@ -1101,8 +1051,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "count": {
           "name": "count",
@@ -1117,8 +1066,7 @@
           "scale": 0,
           "default": "0",
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "last_reset_at": {
           "name": "last_reset_at",
@@ -1133,8 +1081,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         }
       },
       "indexes": [
@@ -1169,8 +1116,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "created_at": {
           "name": "created_at",
@@ -1185,8 +1131,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "updated_at": {
           "name": "updated_at",
@@ -1201,8 +1146,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "user_key": {
           "name": "user_key",
@@ -1217,8 +1161,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "point_grant_status": {
           "name": "point_grant_status",
@@ -1239,8 +1182,7 @@
             "retry",
             "failed",
             "succeeded"
-          ],
-          "mappedType": "enum"
+          ]
         },
         "point_amount": {
           "name": "point_amount",
@@ -1255,8 +1197,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "point_reason": {
           "name": "point_reason",
@@ -1277,8 +1218,7 @@
             "drawing",
             "mission",
             "attendance"
-          ],
-          "mappedType": "enum"
+          ]
         },
         "attempt_count": {
           "name": "attempt_count",
@@ -1293,8 +1233,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "max_attempt_count": {
           "name": "max_attempt_count",
@@ -1309,8 +1248,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "next_retry_at": {
           "name": "next_retry_at",
@@ -1325,8 +1263,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "locked_at": {
           "name": "locked_at",
@@ -1341,8 +1278,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "processed_at": {
           "name": "processed_at",
@@ -1357,8 +1293,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "failed_message": {
           "name": "failed_message",
@@ -1373,8 +1308,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "text"
+          "enumItems": []
         },
         "point_idempotency_key": {
           "name": "point_idempotency_key",
@@ -1389,8 +1323,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
+          "enumItems": []
         }
       },
       "indexes": [
@@ -1481,8 +1414,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "created_at": {
           "name": "created_at",
@@ -1497,8 +1429,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "updated_at": {
           "name": "updated_at",
@@ -1513,8 +1444,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "point_reason": {
           "name": "point_reason",
@@ -1535,8 +1465,7 @@
             "drawing",
             "mission",
             "attendance"
-          ],
-          "mappedType": "enum"
+          ]
         },
         "point_amount": {
           "name": "point_amount",
@@ -1551,8 +1480,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "user_key": {
           "name": "user_key",
@@ -1567,8 +1495,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         }
       },
       "indexes": [
@@ -1626,8 +1553,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "strokes": {
           "name": "strokes",
@@ -1642,8 +1568,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "unknown"
+          "enumItems": []
         }
       },
       "indexes": [
@@ -1678,8 +1603,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "created_at": {
           "name": "created_at",
@@ -1694,8 +1618,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "updated_at": {
           "name": "updated_at",
@@ -1710,8 +1633,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "nickname": {
           "name": "nickname",
@@ -1726,8 +1648,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
+          "enumItems": []
         },
         "strokes": {
           "name": "strokes",
@@ -1742,8 +1663,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "unknown"
+          "enumItems": []
         },
         "drawing_id": {
           "name": "drawing_id",
@@ -1758,8 +1678,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "score": {
           "name": "score",
@@ -1774,8 +1693,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "double"
+          "enumItems": []
         },
         "submitted_at": {
           "name": "submitted_at",
@@ -1790,8 +1708,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "user_key": {
           "name": "user_key",
@@ -1806,8 +1723,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         }
       },
       "indexes": [
@@ -1860,8 +1776,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "created_at": {
           "name": "created_at",
@@ -1876,8 +1791,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "updated_at": {
           "name": "updated_at",
@@ -1892,8 +1806,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "user_key": {
           "name": "user_key",
@@ -1908,8 +1821,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "type": {
           "name": "type",
@@ -1924,8 +1836,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
+          "enumItems": []
         },
         "reference_id": {
           "name": "reference_id",
@@ -1940,8 +1851,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
+          "enumItems": []
         },
         "sent_at": {
           "name": "sent_at",
@@ -1956,8 +1866,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "status": {
           "name": "status",
@@ -1972,8 +1881,7 @@
           "scale": null,
           "default": "'IN_FLIGHT'",
           "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
+          "enumItems": []
         }
       },
       "indexes": [
@@ -2043,8 +1951,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "user_key": {
           "name": "user_key",
@@ -2059,8 +1966,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "channel": {
           "name": "channel",
@@ -2077,8 +1983,7 @@
           "comment": null,
           "enumItems": [
             "contactsViral"
-          ],
-          "mappedType": "enum"
+          ]
         },
         "module_id": {
           "name": "module_id",
@@ -2093,8 +1998,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
+          "enumItems": []
         },
         "created_at": {
           "name": "created_at",
@@ -2109,8 +2013,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "updated_at": {
           "name": "updated_at",
@@ -2125,8 +2028,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         }
       },
       "indexes": [
@@ -2195,8 +2097,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "created_at": {
           "name": "created_at",
@@ -2211,8 +2112,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "updated_at": {
           "name": "updated_at",
@@ -2227,8 +2127,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "cycle_day": {
           "name": "cycle_day",
@@ -2243,8 +2142,7 @@
           "scale": 0,
           "default": "1",
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "last_checked_date": {
           "name": "last_checked_date",
@@ -2259,8 +2157,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "recoverable_day": {
           "name": "recoverable_day",
@@ -2275,8 +2172,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         }
       },
       "indexes": [
@@ -2320,8 +2216,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "created_at": {
           "name": "created_at",
@@ -2336,8 +2231,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "updated_at": {
           "name": "updated_at",
@@ -2352,8 +2246,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "user_key": {
           "name": "user_key",
@@ -2368,8 +2261,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "mission_id": {
           "name": "mission_id",
@@ -2384,8 +2276,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "bigint"
+          "enumItems": []
         },
         "current_count": {
           "name": "current_count",
@@ -2400,8 +2291,7 @@
           "scale": 0,
           "default": "0",
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "completed_at": {
           "name": "completed_at",
@@ -2416,8 +2306,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "last_progressed_at": {
           "name": "last_progressed_at",
@@ -2432,8 +2321,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         }
       },
       "indexes": [
@@ -2525,8 +2413,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "updated_at": {
           "name": "updated_at",
@@ -2541,8 +2428,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         },
         "user_key": {
           "name": "user_key",
@@ -2557,8 +2443,7 @@
           "scale": 0,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
+          "enumItems": []
         },
         "name": {
           "name": "name",
@@ -2573,8 +2458,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
+          "enumItems": []
         },
         "gender": {
           "name": "gender",
@@ -2589,8 +2473,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
+          "enumItems": []
         },
         "birthday": {
           "name": "birthday",
@@ -2605,8 +2488,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "date"
+          "enumItems": []
         },
         "nickname": {
           "name": "nickname",
@@ -2621,8 +2503,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
+          "enumItems": []
         },
         "tutorial_completed_at": {
           "name": "tutorial_completed_at",
@@ -2637,8 +2518,7 @@
           "scale": null,
           "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "enumItems": []
         }
       },
       "indexes": [

--- a/server-toss/src/migrations/Migration20260703033909.ts
+++ b/server-toss/src/migrations/Migration20260703033909.ts
@@ -16,16 +16,10 @@ export class Migration20260703033909 extends Migration {
   }
 
   override down(): void | Promise<void> {
-    this.addSql(
-      `alter table \`prompts\` modify \`strokes\` varchar(255) not null;`,
-    );
+    this.addSql(`alter table \`prompts\` modify \`strokes\` text not null;`);
 
-    this.addSql(
-      `alter table \`rankings\` modify \`strokes\` varchar(255) not null;`,
-    );
+    this.addSql(`alter table \`rankings\` modify \`strokes\` text not null;`);
 
-    this.addSql(
-      `alter table \`drawings\` modify \`strokes\` varchar(255) not null;`,
-    );
+    this.addSql(`alter table \`drawings\` modify \`strokes\` text not null;`);
   }
 }

--- a/server-toss/src/migrations/Migration20260703033909.ts
+++ b/server-toss/src/migrations/Migration20260703033909.ts
@@ -1,0 +1,21 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260703033909 extends Migration {
+
+  override up(): void | Promise<void> {
+    this.addSql(`alter table \`prompts\` modify \`strokes\` mediumtext not null;`);
+
+    this.addSql(`alter table \`rankings\` modify \`strokes\` mediumtext not null;`);
+
+    this.addSql(`alter table \`drawings\` modify \`strokes\` mediumtext not null;`);
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql(`alter table \`prompts\` modify \`strokes\` varchar(255) not null;`);
+
+    this.addSql(`alter table \`rankings\` modify \`strokes\` varchar(255) not null;`);
+
+    this.addSql(`alter table \`drawings\` modify \`strokes\` varchar(255) not null;`);
+  }
+
+}

--- a/server-toss/src/migrations/Migration20260703033909.ts
+++ b/server-toss/src/migrations/Migration20260703033909.ts
@@ -1,21 +1,31 @@
-import { Migration } from '@mikro-orm/migrations';
+import { Migration } from "@mikro-orm/migrations";
 
 export class Migration20260703033909 extends Migration {
-
   override up(): void | Promise<void> {
-    this.addSql(`alter table \`prompts\` modify \`strokes\` mediumtext not null;`);
+    this.addSql(
+      `alter table \`prompts\` modify \`strokes\` mediumtext not null;`,
+    );
 
-    this.addSql(`alter table \`rankings\` modify \`strokes\` mediumtext not null;`);
+    this.addSql(
+      `alter table \`rankings\` modify \`strokes\` mediumtext not null;`,
+    );
 
-    this.addSql(`alter table \`drawings\` modify \`strokes\` mediumtext not null;`);
+    this.addSql(
+      `alter table \`drawings\` modify \`strokes\` mediumtext not null;`,
+    );
   }
 
   override down(): void | Promise<void> {
-    this.addSql(`alter table \`prompts\` modify \`strokes\` varchar(255) not null;`);
+    this.addSql(
+      `alter table \`prompts\` modify \`strokes\` varchar(255) not null;`,
+    );
 
-    this.addSql(`alter table \`rankings\` modify \`strokes\` varchar(255) not null;`);
+    this.addSql(
+      `alter table \`rankings\` modify \`strokes\` varchar(255) not null;`,
+    );
 
-    this.addSql(`alter table \`drawings\` modify \`strokes\` varchar(255) not null;`);
+    this.addSql(
+      `alter table \`drawings\` modify \`strokes\` varchar(255) not null;`,
+    );
   }
-
 }

--- a/server-toss/src/modules/archive/archive.service.ts
+++ b/server-toss/src/modules/archive/archive.service.ts
@@ -8,7 +8,6 @@ import type {
   ArchiveDayResponse,
   ArchiveSummaryResponse,
   SimilarityResponse,
-  Stroke,
 } from "@toss/shared";
 import {
   getSeoulDateKey,
@@ -22,6 +21,7 @@ import { DrawingRepository } from "../drawing/drawing.repository";
 import { PromptService } from "../prompt/prompt.service";
 import { Ranking } from "../ranking/ranking.entity";
 import { RankingRepository } from "../ranking/ranking.repository";
+import { safeParseStrokes } from "src/common/util/safe-parse.util";
 
 @Injectable()
 export class ArchiveService {
@@ -173,7 +173,7 @@ export class ArchiveService {
       drawings: drawings.map((drawing) => ({
         drawingId: Number(drawing.id),
         createdAt: toIsoString(drawing.createdAt),
-        strokes: JSON.parse(drawing.strokes) as Stroke[],
+        strokes: safeParseStrokes(drawing.strokes),
         similarity: JSON.parse(drawing.similarity) as SimilarityResponse,
         isRankedDrawing: rankedDrawingId === String(drawing.id),
       })),

--- a/server-toss/src/modules/drawing/drawing.entity.ts
+++ b/server-toss/src/modules/drawing/drawing.entity.ts
@@ -17,7 +17,7 @@ export class Drawing extends BaseEntity {
   @PrimaryKey({ type: "bigint" })
   id!: bigint;
 
-  @Property({ fieldName: "strokes", type: "text" })
+  @Property({ fieldName: "strokes", type: "mediumtext" })
   strokes!: string;
 
   @Property({ fieldName: "similarity", type: "text" })

--- a/server-toss/src/modules/drawing/drawing.entity.ts
+++ b/server-toss/src/modules/drawing/drawing.entity.ts
@@ -17,7 +17,11 @@ export class Drawing extends BaseEntity {
   @PrimaryKey({ type: "bigint" })
   id!: bigint;
 
-  @Property({ fieldName: "strokes", type: "mediumtext" })
+  @Property({
+    fieldName: "strokes",
+    type: "mediumtext",
+    columnType: "mediumtext",
+  })
   strokes!: string;
 
   @Property({ fieldName: "similarity", type: "text" })

--- a/server-toss/src/modules/drawing/service/drawing.service.ts
+++ b/server-toss/src/modules/drawing/service/drawing.service.ts
@@ -19,6 +19,7 @@ import { Drawing } from "../drawing.entity";
 import { DrawingRepository } from "../drawing.repository";
 import { SaveDrawingDto } from "../dto/save-drawing.dto";
 import { SaveDrawingService } from "./save-drawing.service";
+import { safeParseStrokes } from "src/common/util/safe-parse.util";
 
 type Similarity = ReturnType<typeof scoreFinalSimilarity>;
 const SLOW_STROKES_DURATION_MS = 500;
@@ -147,7 +148,7 @@ export class DrawingService {
 
     const drawings = myDrawings.map((d) => ({
       drawingId: Number(d.id),
-      strokes: JSON.parse(d.strokes) as Stroke[],
+      strokes: safeParseStrokes(d.strokes),
       similarity: JSON.parse(d.similarity) as SimilarityResponse,
     }));
 
@@ -172,7 +173,7 @@ export class DrawingService {
     return {
       drawingId: Number(drawing.id),
       nickname: drawing.user.nickname,
-      strokes: JSON.parse(drawing.strokes) as Stroke[],
+      strokes: safeParseStrokes(drawing.strokes),
       similarity: JSON.parse(drawing.similarity) as SimilarityResponse,
     };
   }

--- a/server-toss/src/modules/prompt/prompt.entity.ts
+++ b/server-toss/src/modules/prompt/prompt.entity.ts
@@ -5,6 +5,6 @@ export class Prompt {
   @PrimaryKey({ type: "bigint" })
   id!: bigint;
 
-  @Property({ type: "mediumtext" })
+  @Property({ type: "mediumtext", columnType: "mediumtext" })
   strokes!: string;
 }

--- a/server-toss/src/modules/prompt/prompt.entity.ts
+++ b/server-toss/src/modules/prompt/prompt.entity.ts
@@ -5,6 +5,6 @@ export class Prompt {
   @PrimaryKey({ type: "bigint" })
   id!: bigint;
 
-  @Property({ type: "text" })
+  @Property({ type: "mediumtext" })
   strokes!: string;
 }

--- a/server-toss/src/modules/ranking/ranking.entity.ts
+++ b/server-toss/src/modules/ranking/ranking.entity.ts
@@ -27,7 +27,7 @@ export class Ranking extends BaseEntity {
   @Property({ type: "varchar(20)", length: 20 })
   nickname!: string;
 
-  @Property({ fieldName: "strokes", type: "text" })
+  @Property({ fieldName: "strokes", type: "mediumtext" })
   strokes!: string;
 
   @Property({ fieldName: "score", type: "double" })

--- a/server-toss/src/modules/ranking/ranking.entity.ts
+++ b/server-toss/src/modules/ranking/ranking.entity.ts
@@ -27,7 +27,11 @@ export class Ranking extends BaseEntity {
   @Property({ type: "varchar(20)", length: 20 })
   nickname!: string;
 
-  @Property({ fieldName: "strokes", type: "mediumtext" })
+  @Property({
+    fieldName: "strokes",
+    type: "mediumtext",
+    columnType: "mediumtext",
+  })
   strokes!: string;
 
   @Property({ fieldName: "score", type: "double" })

--- a/server-toss/src/modules/ranking/ranking.mapper.ts
+++ b/server-toss/src/modules/ranking/ranking.mapper.ts
@@ -1,6 +1,7 @@
-import type { SimilarityResponse, Stroke } from "@toss/shared";
+import type { SimilarityResponse } from "@toss/shared";
 import { Ranking } from "./ranking.entity";
 import type { PodiumItem, RankingListItem } from "./types/ranking.type";
+import { safeParseStrokes } from "src/common/util/safe-parse.util";
 
 const buildFallbackSimilarity = (score: number): SimilarityResponse => ({
   score,
@@ -44,7 +45,7 @@ export const mapRankingToRankingGalleryItem = (
     drawingId: ranking.drawingId.toString(),
     rank: index + 1,
     isMe: userKey !== undefined && ranking.userKey === userKey,
-    strokes: JSON.parse(drawing?.strokes ?? ranking.strokes) as Stroke[],
+    strokes: safeParseStrokes(drawing?.strokes ?? ranking.strokes),
     similarity: drawing
       ? (JSON.parse(drawing.similarity) as SimilarityResponse)
       : buildFallbackSimilarity(ranking.score),


### PR DESCRIPTION
## 개요

MySQL 테이블의 strokes 타입을 MEDIUM TEXT로 수정

## 관련 이슈

### 배경
`/rankings` 조회 시 아래 에러로 500 응답 발생:
```
SyntaxError: Expected ',' or ']' after array element in JSON at position 65535
at mapRankingToRankingGalleryItem (ranking.mapper.js:36:23)
```
원인: `ranking`/`drawing` 테이블의 `strokes` 컬럼이 MySQL `TEXT` 타입(최대 65,535 byte)으로 
정의되어 있었고, 그림 데이터(stroke JSON)가 이 한도를 초과하는 경우 DB에 저장되는 시점에 
잘려서 저장됨. 이후 조회 시 `JSON.parse`가 잘린 문자열을 파싱하다 실패.

## 변경 사항

1. **스키마**: `strokes` 컬럼 타입을 `TEXT` → `MEDIUMTEXT`(최대 16MB)로 변경
2. **코드 방어**: `strokes` 파싱 실패 시 서버 전체가 죽지 않도록 개별 row 단위로 에러를 격리, 
   잘린 데이터는 최대한 복구 가능한 부분까지만 살려서 반환

### 체크리스트

<!-- 리뷰 전에 본인이 확인해야 하는 항목 -->

- [ ] 코드 스타일 가이드/린트 규칙을 준수했습니다.
- [ ] 불필요한 콘솔/디버깅 코드를 제거했습니다.
- [ ] 주석/변수명 등 가독성을 고려했습니다.
- [ ] 영향 범위를 확인했습니다. (다른 페이지/기능 깨짐 여부)
- [ ] API, DB 변경 시 문서화했습니다.
- [ ] 새로운 의존성 추가 시 팀과 공유했습니다.

## 테스트 및 검증 내용

> 어떻게 테스트했고, 어떤 결과를 확인했는지 적어주세요.

## AI 활용 점검

> AI를 어떻게 활용했는지 적어주세요.

## 추가 참고 사항

> 리뷰어가 알아야 할 특이사항, 주의사항 등을 적어주세요.

## 스크린샷 / UI 변경 (선택)

> UI가 변경된 경우 스크린샷을 첨부해주세요.